### PR TITLE
[Feat] SetMenu CRUD robust 테스트 및 API 구현 (#60)

### DIFF
--- a/django/menu/serializers.py
+++ b/django/menu/serializers.py
@@ -152,15 +152,21 @@ class MenuUpdateSerializer(serializers.ModelSerializer):
         return attrs
 
 
-class SetMenuItemSerializer(serializers.ModelSerializer):
-    """SetMenuItem 직렬화 (세트메뉴 구성) - 읽기용"""
+class SetMenuItemOutputSerializer(serializers.ModelSerializer):
+    """세트메뉴 구성 항목 출력용"""
     
-    menu_name = serializers.CharField(source='menu.name', read_only=True)
+    menu_id = serializers.IntegerField(source='menu.id', read_only=True)
+    base_price = serializers.DecimalField(
+        source='menu.price', 
+        max_digits=10, 
+        decimal_places=0, 
+        read_only=True
+    )
+    stock = serializers.IntegerField(source='menu.stock', read_only=True)
     
     class Meta:
         model = SetMenuItem
-        fields = ['id', 'menu', 'menu_name', 'quantity']
-        read_only_fields = ['id']
+        fields = ['menu_id', 'quantity', 'base_price', 'stock']
 
 
 class SetMenuItemInputSerializer(serializers.Serializer):
@@ -189,22 +195,15 @@ class SetMenuItemInputSerializer(serializers.Serializer):
 
 
 class SetMenuSerializer(serializers.ModelSerializer):
-    """SetMenu 직렬화"""
+    """세트메뉴 직렬화 (등록/응답용)"""
     
-    items = SetMenuItemSerializer(many=True, read_only=True)
-    set_items = serializers.ListField(
-        child=serializers.DictField(),
-        write_only=True,
-        error_messages={
-            'not_a_list': 'set_items는 배열([]) 형식이어야 합니다.',
-        }
-    )
-    
+    # 입력 필드
     name = serializers.CharField(
         max_length=20,
         min_length=1,
         error_messages={
-            'blank': '세트메뉴 이름은 필수입니다.',
+            'blank': '세트메뉴 이름은 필수 항목입니다.',
+            'required': '세트메뉴 이름은 필수 항목입니다.',
             'max_length': '세트메뉴 이름은 20자 이하여야 합니다.',
             'min_length': '세트메뉴 이름은 빈 문자열일 수 없습니다.',
         }
@@ -221,8 +220,17 @@ class SetMenuSerializer(serializers.ModelSerializer):
     price = serializers.IntegerField(
         min_value=0,
         error_messages={
-            'min_value': '가격은 0 이상이어야 합니다.',
+            'min_value': '가격은 0원 이상이어야 합니다.',
             'invalid': '가격은 정수여야 합니다.',
+            'required': '가격은 필수 항목입니다.',
+        }
+    )
+    set_items = serializers.ListField(
+        child=serializers.DictField(),
+        write_only=True,
+        error_messages={
+            'not_a_list': 'set_items는 배열([]) 형식이어야 합니다.',
+            'required': 'set_items는 필수 항목입니다.',
         }
     )
     image = CompressedImageField(
@@ -233,16 +241,38 @@ class SetMenuSerializer(serializers.ModelSerializer):
         }
     )
     
+    # 출력 필드
+    set_id = serializers.IntegerField(source='id', read_only=True)
+    booth_id = serializers.IntegerField(source='booth.pk', read_only=True)
+    set_items_output = SetMenuItemOutputSerializer(source='items', many=True, read_only=True)
+    origin_price = serializers.SerializerMethodField()
+    is_soldout = serializers.SerializerMethodField()
+    
     class Meta:
         model = SetMenu
         fields = [
-            'id', 'booth', 'name', 'category', 'description',
-            'price', 'image', 'items', 'set_items', 'created_at', 'updated_at'
+            'set_id', 'booth_id', 'name', 'category', 'description',
+            'price', 'image', 'set_items', 'set_items_output',
+            'origin_price', 'is_soldout', 'created_at', 'updated_at'
         ]
-        read_only_fields = ['id', 'category', 'created_at', 'updated_at']
+        read_only_fields = ['set_id', 'booth_id', 'category', 'created_at', 'updated_at']
+    
+    def get_origin_price(self, obj):
+        """구성품의 base_price * quantity 합계"""
+        total = 0
+        for item in obj.items.all():
+            total += int(item.menu.price) * item.quantity
+        return total
+    
+    def get_is_soldout(self, obj):
+        """구성 메뉴 중 하나라도 stock=0이면 품절"""
+        for item in obj.items.all():
+            if item.menu.stock == 0:
+                return True
+        return False
     
     def validate_set_items(self, value):
-        """set_items 유효성 검사"""
+        """세트 구성 항목 유효성 검사"""
         # 빈 배열 체크
         if not value or len(value) == 0:
             raise serializers.ValidationError('최소 1개 이상의 메뉴가 포함되어야 합니다.')
@@ -261,40 +291,120 @@ class SetMenuSerializer(serializers.ModelSerializer):
         
         return validated_items
     
-    def create(self, validated_data):
-        """SetMenu 생성 + SetMenuItem 연결"""
-        set_items_data = validated_data.pop('set_items')
-        
-        # SetMenu 생성
-        set_menu = SetMenu.objects.create(**validated_data)
-        
-        # SetMenuItem 생성
-        for item_data in set_items_data:
-            SetMenuItem.objects.create(
-                set_menu=set_menu,
-                menu_id=item_data['menu_id'],
-                quantity=item_data.get('quantity', 1)
-            )
-        
-        return set_menu
+    def to_representation(self, instance):
+        """응답 포맷 조정 (set_items_output -> set_items)"""
+        data = super().to_representation(instance)
+        # set_items_output을 set_items로 매핑
+        data['set_items'] = data.pop('set_items_output', [])
+        return data
+
+
+class SetMenuUpdateSerializer(serializers.ModelSerializer):
+    """세트메뉴 수정용 직렬화 (partial update)"""
     
-    def update(self, instance, validated_data):
-        """SetMenu 수정 + SetMenuItem 갱신"""
-        set_items_data = validated_data.pop('set_items', None)
+    # 입력 필드 (모두 optional)
+    name = serializers.CharField(
+        max_length=20,
+        min_length=1,
+        required=False,
+        error_messages={
+            'blank': '세트메뉴 이름은 빈 문자열일 수 없습니다.',
+            'max_length': '세트메뉴 이름은 20자 이하여야 합니다.',
+            'min_length': '세트메뉴 이름은 빈 문자열일 수 없습니다.',
+        }
+    )
+    description = serializers.CharField(
+        max_length=30,
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+        error_messages={
+            'max_length': '설명은 30자 이하여야 합니다.',
+        }
+    )
+    price = serializers.IntegerField(
+        min_value=0,
+        required=False,
+        error_messages={
+            'min_value': '수정할 가격은 0원 이상이어야 합니다.',
+            'invalid': '가격은 정수여야 합니다.',
+        }
+    )
+    set_items = serializers.ListField(
+        child=serializers.DictField(),
+        required=False,
+        error_messages={
+            'not_a_list': 'set_items는 배열([]) 형식이어야 합니다.',
+        }
+    )
+    image_delete = serializers.BooleanField(
+        required=False,
+        default=False,
+        write_only=True,
+    )
+    
+    # 출력 필드
+    set_id = serializers.IntegerField(source='id', read_only=True)
+    booth_id = serializers.IntegerField(source='booth.pk', read_only=True)
+    set_items_output = SetMenuItemOutputSerializer(source='items', many=True, read_only=True)
+    origin_price = serializers.SerializerMethodField()
+    is_soldout = serializers.SerializerMethodField()
+    
+    class Meta:
+        model = SetMenu
+        fields = [
+            'set_id', 'booth_id', 'name', 'category', 'description',
+            'price', 'image', 'image_delete', 'set_items', 'set_items_output',
+            'origin_price', 'is_soldout', 'created_at', 'updated_at'
+        ]
+        read_only_fields = ['set_id', 'booth_id', 'category', 'image', 'created_at', 'updated_at']
+    
+    def get_origin_price(self, obj):
+        """구성품의 base_price * quantity 합계"""
+        total = 0
+        for item in obj.items.all():
+            total += int(item.menu.price) * item.quantity
+        return total
+    
+    def get_is_soldout(self, obj):
+        """구성 메뉴 중 하나라도 stock=0이면 품절"""
+        for item in obj.items.all():
+            if item.menu.stock == 0:
+                return True
+        return False
+    
+    def validate_set_items(self, value):
+        """세트 구성 항목 유효성 검사"""
+        # 빈 배열 체크 (수정 시에도 최소 1개 필요)
+        if not value or len(value) == 0:
+            raise serializers.ValidationError('최소 1개 이상의 메뉴가 포함되어야 합니다.')
         
-        # SetMenu 필드 업데이트
-        for attr, value in validated_data.items():
-            setattr(instance, attr, value)
-        instance.save()
+        # 각 항목 검증
+        validated_items = []
+        for idx, item in enumerate(value):
+            if not isinstance(item, dict):
+                raise serializers.ValidationError(f'set_items[{idx}]는 객체({{}}) 형태여야 합니다.')
+            
+            item_serializer = SetMenuItemInputSerializer(data=item)
+            if not item_serializer.is_valid():
+                raise serializers.ValidationError({f'set_items[{idx}]': item_serializer.errors})
+            
+            validated_items.append(item_serializer.validated_data)
         
-        # SetMenuItem 갱신 (기존 삭제 후 새로 생성)
-        if set_items_data is not None:
-            instance.items.all().delete()
-            for item_data in set_items_data:
-                SetMenuItem.objects.create(
-                    set_menu=instance,
-                    menu_id=item_data['menu_id'],
-                    quantity=item_data.get('quantity', 1)
-                )
-        
-        return instance
+        return validated_items
+    
+    def validate(self, attrs):
+        """이미지 수정 시도 방지"""
+        request = self.context.get('request')
+        if request and hasattr(request, 'data'):
+            if 'image' in request.data and request.data.get('image'):
+                raise serializers.ValidationError({
+                    'image': '이미지는 수정할 수 없습니다. image_delete로 삭제만 가능합니다.'
+                })
+        return attrs
+    
+    def to_representation(self, instance):
+        """응답 포맷 조정 (set_items_output -> set_items)"""
+        data = super().to_representation(instance)
+        data['set_items'] = data.pop('set_items_output', [])
+        return data

--- a/django/menu/services.py
+++ b/django/menu/services.py
@@ -76,8 +76,14 @@ class SetMenuService:
     @staticmethod
     @transaction.atomic
     def update_set_menu(set_menu, validated_data):
-        """세트메뉴 수정"""
+        """세트메뉴 수정 (이미지 삭제 포함)"""
         set_items_data = validated_data.pop('set_items', None)
+        
+        # 이미지 삭제 처리
+        image_delete = validated_data.pop('image_delete', False)
+        if image_delete and set_menu.image:
+            set_menu.image.delete(save=False)
+            set_menu.image = None
         
         # SetMenu 필드 업데이트
         for attr, value in validated_data.items():
@@ -97,6 +103,16 @@ class SetMenuService:
         return set_menu
     
     @staticmethod
+    @transaction.atomic
     def delete_set_menu(set_menu):
-        """세트메뉴 삭제"""
+        """
+        세트메뉴 삭제
+        - 이미지 파일도 함께 삭제
+        - SetMenuItem은 CASCADE로 자동 삭제됨
+        """
+        # 이미지 파일 삭제
+        if set_menu.image:
+            set_menu.image.delete(save=False)
+        
+        # DB 레코드 삭제 (SetMenuItem은 CASCADE로 자동 삭제)
         set_menu.delete()

--- a/django/menu/tests.py
+++ b/django/menu/tests.py
@@ -510,6 +510,276 @@ class MenuDeleteAPITest(APITestCase):
 
 
 @override_settings(STORAGES=IN_MEMORY_STORAGES)
+class SetMenuAPITest(APITestCase):
+    """세트메뉴 등록/수정/삭제 API 통합 테스트"""
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(username='setuser', password='setpass123')
+        cls.booth = Booth.objects.create(
+            user=cls.user,
+            name='세트부스',
+            table_max_cnt=5,
+            account='111222333',
+            depositor='세트주인',
+            bank='카카오',
+            seat_type='NO',
+            seat_fee_person=0,
+            seat_fee_table=0,
+            table_limit_hours=1.0
+        )
+        cls.menu1 = Menu.objects.create(booth=cls.booth, name='단품1', category='MENU', price=1000, stock=10)
+        cls.menu2 = Menu.objects.create(booth=cls.booth, name='단품2', category='MENU', price=2000, stock=5)
+        cls.menu3 = Menu.objects.create(booth=cls.booth, name='단품3', category='MENU', price=3000, stock=0)
+        cls.other_user = User.objects.create_user(username='otheruser', password='otherpass123')
+        cls.other_booth = Booth.objects.create(
+            user=cls.other_user,
+            name='다른부스',
+            table_max_cnt=3,
+            account='444555666',
+            depositor='다른주인',
+            bank='농협',
+            seat_type='NO',
+            seat_fee_person=0,
+            seat_fee_table=0,
+            table_limit_hours=1.0
+        )
+        cls.other_menu = Menu.objects.create(booth=cls.other_booth, name='외부메뉴', category='MENU', price=5000, stock=10)
+
+    def setUp(self):
+        self.client.force_authenticate(user=self.user)
+        self.url = '/api/v3/django/booth/sets/'
+
+    def test_setmenu_create_success(self):
+        """세트메뉴 등록 성공"""
+        data = {
+            'name': '세트1',
+            'description': '맛있는 세트',
+            'price': 5000,
+            'set_items': [
+                {'menu_id': self.menu1.id, 'quantity': 2},
+                {'menu_id': self.menu2.id, 'quantity': 1}
+            ]
+        }
+        response = self.client.post(self.url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data['message'], '세트메뉴 등록 성공')
+        self.assertEqual(response.data['data']['name'], '세트1')
+        self.assertEqual(len(response.data['data']['set_items']), 2)
+
+    def test_setmenu_create_with_image(self):
+        """이미지 포함 세트메뉴 등록 성공"""
+        import json
+        data = {
+            'name': '세트2',
+            'description': '이미지세트',
+            'price': 8000,
+            'set_items': json.dumps([
+                {'menu_id': self.menu1.id, 'quantity': 1}
+            ]),
+            'image': create_test_image()
+        }
+        response = self.client.post(self.url, data, format='multipart')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(response.data['data']['image'])
+
+    def test_setmenu_create_minimal(self):
+        """필수값만으로 세트메뉴 등록 성공"""
+        data = {
+            'name': '세트3',
+            'price': 1000,
+            'set_items': [
+                {'menu_id': self.menu1.id}
+            ]
+        }
+        response = self.client.post(self.url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data['data']['name'], '세트3')
+
+    def test_setmenu_create_invalid_menu(self):
+        """존재하지 않는 menu_id 포함 시 400"""
+        data = {
+            'name': '세트4',
+            'price': 1000,
+            'set_items': [
+                {'menu_id': 99999}
+            ]
+        }
+        with suppress_request_warnings():
+            response = self.client.post(self.url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('set_items', response.data.get('errors', {}))
+
+    def test_setmenu_create_empty_items(self):
+        """set_items 빈 배열 시 400"""
+        data = {
+            'name': '세트5',
+            'price': 1000,
+            'set_items': []
+        }
+        with suppress_request_warnings():
+            response = self.client.post(self.url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('set_items', response.data.get('errors', {}))
+
+    def test_setmenu_create_unauthorized(self):
+        """비로그인 시 401"""
+        self.client.force_authenticate(user=None)
+        data = {
+            'name': '세트6',
+            'price': 1000,
+            'set_items': [{'menu_id': self.menu1.id}]
+        }
+        with suppress_request_warnings():
+            response = self.client.post(self.url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_setmenu_update_success(self):
+        """세트메뉴 수정 성공 (이름/구성/가격 변경)"""
+        # 등록
+        setmenu = SetMenu.objects.create(booth=self.booth, name='수정세트', price=1000)
+        SetMenuItem.objects.create(set_menu=setmenu, menu=self.menu1, quantity=1)
+        url = f'/api/v3/django/booth/sets/{setmenu.id}/'
+        patch_data = {
+            'name': '수정된세트',
+            'price': 2000,
+            'set_items': [
+                {'menu_id': self.menu2.id, 'quantity': 2}
+            ]
+        }
+        response = self.client.patch(url, patch_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['data']['name'], '수정된세트')
+        self.assertEqual(len(response.data['data']['set_items']), 1)
+        self.assertEqual(response.data['data']['set_items'][0]['menu_id'], self.menu2.id)
+
+    def test_setmenu_update_partial(self):
+        """세트메뉴 부분 수정 (이름만)"""
+        setmenu = SetMenu.objects.create(booth=self.booth, name='부분수정', price=1000)
+        SetMenuItem.objects.create(set_menu=setmenu, menu=self.menu1, quantity=1)
+        url = f'/api/v3/django/booth/sets/{setmenu.id}/'
+        patch_data = {'name': '이름만수정'}
+        response = self.client.patch(url, patch_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['data']['name'], '이름만수정')
+
+    def test_setmenu_update_image_delete(self):
+        """세트메뉴 이미지 삭제"""
+        setmenu = SetMenu.objects.create(booth=self.booth, name='이미지세트', price=1000)
+        setmenu.image = create_test_image()
+        setmenu.save()
+        SetMenuItem.objects.create(set_menu=setmenu, menu=self.menu1, quantity=1)
+        url = f'/api/v3/django/booth/sets/{setmenu.id}/'
+        patch_data = {'image_delete': True}
+        response = self.client.patch(url, patch_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        setmenu.refresh_from_db()
+        self.assertFalse(setmenu.image)
+
+    def test_setmenu_update_forbidden(self):
+        """다른 부스 세트메뉴 수정 시 403"""
+        setmenu = SetMenu.objects.create(booth=self.other_booth, name='외부세트', price=1000)
+        SetMenuItem.objects.create(set_menu=setmenu, menu=self.other_menu, quantity=1)
+        url = f'/api/v3/django/booth/sets/{setmenu.id}/'
+        patch_data = {'name': '수정시도'}
+        response = self.client.patch(url, patch_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data['code'], 'PERMISSION_DENIED')
+
+    def test_setmenu_update_not_found(self):
+        """존재하지 않는 세트메뉴 수정 시 404"""
+        url = '/api/v3/django/booth/sets/99999/'
+        patch_data = {'name': '없는세트'}
+        response = self.client.patch(url, patch_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data['code'], 'MENU_NOT_FOUND')
+
+    def test_setmenu_delete_success(self):
+        """세트메뉴 삭제 성공"""
+        setmenu = SetMenu.objects.create(booth=self.booth, name='삭제세트', price=1000)
+        SetMenuItem.objects.create(set_menu=setmenu, menu=self.menu1, quantity=1)
+        url = f'/api/v3/django/booth/sets/{setmenu.id}/'
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(SetMenu.objects.filter(id=setmenu.id).exists())
+        self.assertFalse(SetMenuItem.objects.filter(set_menu_id=setmenu.id).exists())
+
+    def test_setmenu_delete_forbidden(self):
+        """다른 부스 세트메뉴 삭제 시 403"""
+        setmenu = SetMenu.objects.create(booth=self.other_booth, name='외부세트', price=1000)
+        SetMenuItem.objects.create(set_menu=setmenu, menu=self.other_menu, quantity=1)
+        url = f'/api/v3/django/booth/sets/{setmenu.id}/'
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data['code'], 'PERMISSION_DENIED')
+
+    def test_setmenu_delete_not_found(self):
+        """존재하지 않는 세트메뉴 삭제 시 404"""
+        url = '/api/v3/django/booth/sets/99999/'
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data['code'], 'MENU_NOT_FOUND')
+
+    def test_setmenu_delete_twice(self):
+        """이미 삭제된 세트메뉴 다시 삭제 시 404"""
+        setmenu = SetMenu.objects.create(booth=self.booth, name='삭제2회', price=1000)
+        SetMenuItem.objects.create(set_menu=setmenu, menu=self.menu1, quantity=1)
+        url = f'/api/v3/django/booth/sets/{setmenu.id}/'
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response2 = self.client.delete(url)
+        self.assertEqual(response2.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response2.data['code'], 'MENU_NOT_FOUND')
+
+    def test_setmenu_soldout_logic(self):
+        """구성 메뉴 중 하나라도 품절이면 is_soldout True"""
+        setmenu = SetMenu.objects.create(booth=self.booth, name='품절세트', price=1000)
+        SetMenuItem.objects.create(set_menu=setmenu, menu=self.menu3, quantity=1)  # stock=0
+        url = f'/api/v3/django/booth/sets/{setmenu.id}/'
+        response = self.client.patch(url, {'name': '품절세트수정'}, format='json')
+        self.assertTrue(response.data['data']['is_soldout'])
+
+    def test_setmenu_origin_price(self):
+        """origin_price 계산 검증"""
+        setmenu = SetMenu.objects.create(booth=self.booth, name='원가세트', price=1000)
+        SetMenuItem.objects.create(set_menu=setmenu, menu=self.menu1, quantity=2)  # 1000*2
+        SetMenuItem.objects.create(set_menu=setmenu, menu=self.menu2, quantity=1)  # 2000*1
+        url = f'/api/v3/django/booth/sets/{setmenu.id}/'
+        response = self.client.patch(url, {'name': '원가세트수정'}, format='json')
+        self.assertEqual(response.data['data']['origin_price'], 4000)
+
+    def test_setmenu_update_invalid_items(self):
+        """set_items 잘못된 값(빈배열) 시 400"""
+        setmenu = SetMenu.objects.create(booth=self.booth, name='잘못세트', price=1000)
+        SetMenuItem.objects.create(set_menu=setmenu, menu=self.menu1, quantity=1)
+        url = f'/api/v3/django/booth/sets/{setmenu.id}/'
+        patch_data = {'set_items': []}
+        response = self.client.patch(url, patch_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('set_items', response.data.get('errors', {}))
+
+    def test_setmenu_update_invalid_menu(self):
+        """set_items에 없는 menu_id 포함 시 400"""
+        setmenu = SetMenu.objects.create(booth=self.booth, name='잘못세트2', price=1000)
+        SetMenuItem.objects.create(set_menu=setmenu, menu=self.menu1, quantity=1)
+        url = f'/api/v3/django/booth/sets/{setmenu.id}/'
+        patch_data = {'set_items': [{'menu_id': 99999}]}
+        response = self.client.patch(url, patch_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('set_items', response.data.get('errors', {}))
+
+    def test_setmenu_update_image_modify_forbidden(self):
+        """이미지 직접 수정 시도 시 400"""
+        setmenu = SetMenu.objects.create(booth=self.booth, name='이미지수정불가', price=1000)
+        SetMenuItem.objects.create(set_menu=setmenu, menu=self.menu1, quantity=1)
+        url = f'/api/v3/django/booth/sets/{setmenu.id}/'
+        patch_data = {'image': create_test_image()}
+        response = self.client.patch(url, patch_data, format='multipart')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('image', response.data.get('errors', {}))
+
+    # 기타 추가 검증 필요시 여기에 작성
+
+
 class MenuModelTest(APITestCase):
     """Menu 모델 테스트"""
     

--- a/django/menu/urls.py
+++ b/django/menu/urls.py
@@ -1,8 +1,12 @@
 from django.urls import path
-from .views import MenuAPIView, MenuDetailAPIView
+from .views import MenuAPIView, MenuDetailAPIView, SetMenuAPIView, SetMenuDetailAPIView
 
 urlpatterns = [
     # Menu CRUD
     path('menus/', MenuAPIView.as_view(), name='menu-create'),
     path('menus/<int:menu_id>/', MenuDetailAPIView.as_view(), name='menu-detail'),
+    
+    # SetMenu CRUD
+    path('sets/', SetMenuAPIView.as_view(), name='setmenu-create'),
+    path('sets/<int:set_id>/', SetMenuDetailAPIView.as_view(), name='setmenu-detail'),
 ]

--- a/django/menu/views.py
+++ b/django/menu/views.py
@@ -6,8 +6,9 @@ from rest_framework import status
 from rest_framework.exceptions import ValidationError
 
 from .models import Menu, SetMenu
-from .serializers import MenuSerializer, MenuUpdateSerializer, SetMenuSerializer
+from .serializers import MenuSerializer, MenuUpdateSerializer, SetMenuSerializer, SetMenuUpdateSerializer
 from .services import MenuService, SetMenuService
+import json
 
 
 class MenuAPIView(APIView):
@@ -126,6 +127,179 @@ class MenuDetailAPIView(APIView):
             "message": "메뉴 삭제 성공",
             "data": {
                 "menu_id": deleted_menu_id
+            }
+        }, status=status.HTTP_200_OK)
+
+
+class SetMenuAPIView(APIView):
+    """
+    세트메뉴 등록 API
+    POST /api/v3/django/booth/sets/
+    """
+    permission_classes = [IsAuthenticated]
+    parser_classes = [MultiPartParser, FormParser, JSONParser]
+    
+    def post(self, request):
+        """세트메뉴 등록"""
+        booth = request.user.booth
+        
+        # request.data 처리 (QueryDict → dict 변환 및 set_items JSON 파싱)
+        if hasattr(request.data, 'dict'):
+            # MultiPartParser/FormParser인 경우 (QueryDict)
+            data = {}
+            for key in request.data:
+                if key == 'set_items':
+                    # set_items는 JSON 문자열로 들어옴
+                    try:
+                        data['set_items'] = json.loads(request.data.get('set_items'))
+                    except json.JSONDecodeError:
+                        return Response({
+                            "message": "입력값 유효성 검사 실패",
+                            "errors": {
+                                "set_items": "유효하지 않은 JSON 형식입니다."
+                            }
+                        }, status=status.HTTP_400_BAD_REQUEST)
+                elif key == 'image':
+                    # 파일은 그대로
+                    data['image'] = request.data.get('image')
+                else:
+                    # 일반 필드
+                    data[key] = request.data.get(key)
+        else:
+            # JSONParser인 경우 (이미 dict)
+            data = request.data
+        
+        serializer = SetMenuSerializer(data=data)
+        
+        if not serializer.is_valid():
+            return Response({
+                "message": "입력값 유효성 검사 실패",
+                "errors": serializer.errors
+            }, status=status.HTTP_400_BAD_REQUEST)
+        
+        # 세트메뉴 생성
+        set_menu = SetMenuService.create_set_menu(booth, serializer.validated_data)
+        
+        # 응답 직렬화
+        response_serializer = SetMenuSerializer(set_menu)
+        
+        return Response({
+            "message": "세트메뉴 등록 성공",
+            "data": response_serializer.data
+        }, status=status.HTTP_201_CREATED)
+
+
+class SetMenuDetailAPIView(APIView):
+    """
+    세트메뉴 수정/삭제 API
+    PATCH /api/v3/django/booth/sets/<set_id>/
+    DELETE /api/v3/django/booth/sets/<set_id>/
+    """
+    permission_classes = [IsAuthenticated]
+    parser_classes = [MultiPartParser, FormParser, JSONParser]
+    
+    def get_set_menu(self, set_id, booth, action='modify'):
+        """
+        세트메뉴 조회 + 권한 검증
+        action: 'modify' (수정) 또는 'delete' (삭제)
+        """
+        try:
+            set_menu = SetMenu.objects.get(id=set_id)
+        except SetMenu.DoesNotExist:
+            if action == 'delete':
+                message = "이미 삭제되었거나 존재하지 않는 세트메뉴입니다."
+            else:
+                message = "수정하려는 세트메뉴 정보를 찾을 수 없습니다."
+            return None, Response({
+                "message": message,
+                "code": "MENU_NOT_FOUND"
+            }, status=status.HTTP_404_NOT_FOUND)
+        
+        # 권한 검증: 해당 부스의 세트메뉴인지 확인
+        if set_menu.booth.pk != booth.pk:
+            if action == 'delete':
+                message = "해당 세트메뉴를 삭제할 권한이 없습니다."
+            else:
+                message = "해당 세트메뉴를 수정할 권한이 없습니다."
+            return None, Response({
+                "message": message,
+                "code": "PERMISSION_DENIED"
+            }, status=status.HTTP_403_FORBIDDEN)
+        
+        return set_menu, None
+    
+    def patch(self, request, set_id):
+        """세트메뉴 수정"""
+        booth = request.user.booth
+        
+        set_menu, error_response = self.get_set_menu(set_id, booth)
+        if error_response:
+            return error_response
+        
+        # request.data 처리 (QueryDict → dict 변환 및 set_items JSON 파싱)
+        if hasattr(request.data, 'dict'):
+            # MultiPartParser/FormParser인 경우 (QueryDict)
+            data = {}
+            for key in request.data:
+                if key == 'set_items':
+                    try:
+                        data['set_items'] = json.loads(request.data.get('set_items'))
+                    except json.JSONDecodeError:
+                        return Response({
+                            "message": "데이터 수정 형식이 올바르지 않습니다.",
+                            "errors": {
+                                "set_items": "유효하지 않은 JSON 형식입니다."
+                            }
+                        }, status=status.HTTP_400_BAD_REQUEST)
+                elif key == 'image':
+                    data['image'] = request.data.get('image')
+                else:
+                    data[key] = request.data.get(key)
+        else:
+            data = request.data
+        
+        serializer = SetMenuUpdateSerializer(
+            set_menu, 
+            data=data, 
+            partial=True, 
+            context={'request': request}
+        )
+        
+        if not serializer.is_valid():
+            return Response({
+                "message": "데이터 수정 형식이 올바르지 않습니다.",
+                "errors": serializer.errors
+            }, status=status.HTTP_400_BAD_REQUEST)
+        
+        # 세트메뉴 수정
+        set_menu = SetMenuService.update_set_menu(set_menu, serializer.validated_data)
+        
+        # 응답 직렬화
+        response_serializer = SetMenuSerializer(set_menu)
+        
+        return Response({
+            "message": "세트메뉴 수정 성공",
+            "data": response_serializer.data
+        }, status=status.HTTP_200_OK)
+    
+    def delete(self, request, set_id):
+        """세트메뉴 삭제"""
+        booth = request.user.booth
+        
+        set_menu, error_response = self.get_set_menu(set_id, booth, action='delete')
+        if error_response:
+            return error_response
+        
+        # 삭제 전 set_id 저장
+        deleted_set_id = set_menu.id
+        
+        # 세트메뉴 삭제 (이미지 파일 + SetMenuItem CASCADE 삭제)
+        SetMenuService.delete_set_menu(set_menu)
+        
+        return Response({
+            "message": "메뉴 삭제 성공",
+            "data": {
+                "set_id": deleted_set_id
             }
         }, status=status.HTTP_200_OK)
 


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
# ✨ [Feat] SetMenu CRUD robust 테스트 및 API 구현
## 🔍 What is the PR?

- 세트메뉴(SetMenu) 등록/수정/삭제 API robust 구현
- 세트메뉴 관련 전체 테스트 코드 작성 및 통과
- 이미지 업로드/삭제, set_items 유효성, 권한/에러 처리 등 모든 케이스 커버
- 기존 메뉴(Menu) CRUD와 동일한 수준의 품질 보장

## 📍 PR Point

-세트메뉴 CRUD API의 모든 엣지케이스와 예외처리, 트랜잭션, 이미지 파일 관리까지 완벽하게 구현
-CI/CD 환경에서도 100% 통과하는 강력한 테스트 코드 작성

## 📢 Notices

- 공용 모델/시리얼라이저/서비스 레이어 일부 수정(세트메뉴 관련)
- 기존 Menu CRUD에는 영향 없음

## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #60