### PR TITLE
[feat]: 사용자 메뉴판 조회 API 및 테스트 통합

### DIFF
--- a/django/booth/services.py
+++ b/django/booth/services.py
@@ -1,20 +1,18 @@
 from booth.models import Booth
+from menu.models import Menu
 
 class BoothService:
 
     @staticmethod
     def create_booth_for_user(user, booth_data):
-        """유저 생성 시 부스 데이트 만드는 함수
-
+        """유저 생성 시 부스 데이터 만드는 함수
         Args:
             user (User): 유저 객체
             booth_data (dict): 부스 데이터
-
         Returns:
             생성한 Booth 객체
         """
-        # from menu.models import Menu  # TODO: Menu 모델 구현 후 활성화
-        from table.models import Table  
+        from table.models import Table
 
         # 3. Booth 객체 생성
         booth = Booth.objects.create(
@@ -30,27 +28,34 @@ class BoothService:
             seat_fee_table=booth_data.get('seat_fee_table'),
         )
 
-        # TODO: Menu 모델 확립 후 다시 구현
-        # 이건 여기 두는게 나을 듯
         # 4. 테이블 이용료 메뉴 자동 생성
-        # if booth.seat_type == "PP":
-        #     Menu.objects.create(
-        #         booth=booth,
-        #         menu_name="테이블 이용료(1인당)",
-        #         menu_description="좌석 이용 요금(1인 기준)",
-        #         menu_category="seat_fee",
-        #         menu_price=booth.seat_fee_person,
-        #         menu_amount=999999  # 사실상 무제한
-        #     )
-        # elif booth.seat_type == "PT":
-        #     Menu.objects.create(
-        #         booth=booth,
-        #         menu_name="테이블 이용료(테이블당)",
-        #         menu_description="좌석 이용 요금(테이블 기준)",
-        #         menu_category="seat_fee",
-        #         menu_price=booth.seat_fee_table,
-        #         menu_amount=999999
-        #     )
+        if booth.seat_type == "PP":
+            Menu.objects.create(
+                booth=booth,
+                name="테이블 이용료",
+                category="FEE",
+                description="인원 수",
+                price=booth.seat_fee_person or 0,
+                stock=9999
+            )
+        elif booth.seat_type == "PT":
+            Menu.objects.create(
+                booth=booth,
+                name="테이블 이용료",
+                category="FEE",
+                description="테이블",
+                price=booth.seat_fee_table or 0,
+                stock=9999
+            )
+        else:
+            Menu.objects.create(
+                booth=booth,
+                name="테이블 이용료",
+                category="FEE",
+                description="FREE",
+                price=0,
+                stock=9999
+            )
 
         # 테이블 생성
         for i in range(1, booth.table_max_cnt + 1):
@@ -58,19 +63,31 @@ class BoothService:
                 booth=booth,
                 table_num=i
             )
-
         return booth
 
     @staticmethod
     def update_booth(booth, booth_data):
-        """부스 마이페이지 데이터 업데이트
-
+        """부스 마이페이지 데이터 업데이트 및 FEE 메뉴 동기화
         Args:
             booth_data (dict): 변경할 부스 데이터
         """
-        # TODO : 테이블 요금 변경 시 menu에 연결된 기본 요금 변경 필요...
+        # 기존 값 변경
         for key, value in booth_data.items():
             setattr(booth, key, value)
         booth.save()
+
+        # FEE 메뉴 동기화
+        fee_menu = Menu.objects.filter(booth=booth, category="FEE").first()
+        if fee_menu:
+            if booth.seat_type == "PP":
+                fee_menu.price = booth.seat_fee_person or 0
+                fee_menu.description = "인원 수"
+            elif booth.seat_type == "PT":
+                fee_menu.price = booth.seat_fee_table or 0
+                fee_menu.description = "테이블"
+            else:
+                fee_menu.price = 0
+                fee_menu.description = "FREE"
+            fee_menu.save()
 
 

--- a/django/menu/tests.py
+++ b/django/menu/tests.py
@@ -1,3 +1,62 @@
+# 사용자 메뉴판 조회 API 테스트 (UserMenuListAPIView)
+
+from rest_framework.test import APITestCase
+from rest_framework import status
+from table.models import Table, TableUsage
+from menu.models import SetMenu
+from django.utils import timezone
+
+class UserMenuListAPITest(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username='testuser', password='testpass123')
+        self.booth = Booth.objects.create(
+            user=self.user,
+            name='테스트부스',
+            table_max_cnt=10,
+            account='1234567890',
+            depositor='홍길동',
+            bank='신한은행',
+            seat_type='PP',
+            seat_fee_person=8000,
+            seat_fee_table=0,
+            table_limit_hours=2.0
+        )
+        self.table = Table.objects.create(booth=self.booth, table_num=3)
+        self.menu = Menu.objects.create(booth=self.booth, name='피자', category='MENU', price=20000, stock=5)
+        self.setmenu = SetMenu.objects.create(booth=self.booth, name='A세트', price=30000, description='세트 메뉴', image=None)
+        self.usage = TableUsage.objects.create(table=self.table, started_at=timezone.now())
+        self.url = f'/api/v3/django/booth/{self.booth.pk}/menu-list/'
+
+    def test_menu_list_without_table_num(self):
+        """table_num 없이 메뉴판 조회시 table_info 미포함, 메뉴 데이터만 반환"""
+        resp = self.client.get(self.url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertIn('data', resp.data)
+        self.assertNotIn('table_info', resp.data)
+        self.assertIn('FEE', resp.data['data'])
+        self.assertIn('MENU', resp.data['data'])
+
+    def test_menu_list_with_valid_table_num(self):
+        """유효한 table_num으로 조회시 table_info 포함, usage id 포함"""
+        resp = self.client.get(self.url + '?table_num=3')
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertIn('table_info', resp.data)
+        self.assertEqual(resp.data['table_info']['table_number'], 3)
+        self.assertEqual(resp.data['table_info']['table_usage_id'], self.usage.id)
+        self.assertIn('FEE', resp.data['data'])
+        self.assertIn('MENU', resp.data['data'])
+
+    def test_menu_list_with_invalid_table_num(self):
+        """존재하지 않는 table_num으로 조회시 404 반환"""
+        resp = self.client.get(self.url + '?table_num=999')
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(resp.data['code'], 'TABLE_NOT_FOUND')
+
+    def test_menu_list_with_invalid_table_num_type(self):
+        """숫자가 아닌 table_num으로 조회시 400 반환"""
+        resp = self.client.get(self.url + '?table_num=abc')
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(resp.data['code'], 'TABLE_NUMBER_INVALID')
 import io
 from PIL import Image
 

--- a/django/menu/urls.py
+++ b/django/menu/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import MenuAPIView, MenuDetailAPIView, SetMenuAPIView, SetMenuDetailAPIView
+from .views import MenuAPIView, MenuDetailAPIView, SetMenuAPIView, SetMenuDetailAPIView, BoothMenuListAPIView, UserMenuListAPIView
 
 urlpatterns = [
     # Menu CRUD
@@ -9,4 +9,8 @@ urlpatterns = [
     # SetMenu CRUD
     path('sets/', SetMenuAPIView.as_view(), name='setmenu-create'),
     path('sets/<int:set_id>/', SetMenuDetailAPIView.as_view(), name='setmenu-detail'),
+    
+    # 전체 메뉴판 조회
+    path('menu-list/', BoothMenuListAPIView.as_view(), name='booth-menu-list'),
+    path('<int:booth_id>/menu-list/', UserMenuListAPIView.as_view()),
 ]

--- a/django/menu/views.py
+++ b/django/menu/views.py
@@ -4,132 +4,89 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.parsers import MultiPartParser, FormParser, JSONParser
 from rest_framework import status
 from rest_framework.exceptions import ValidationError
-
-from .models import Menu, SetMenu
+from booth.models import Booth
+from .models import Menu, SetMenu, SetMenuItem
 from .serializers import MenuSerializer, MenuUpdateSerializer, SetMenuSerializer, SetMenuUpdateSerializer
 from .services import MenuService, SetMenuService
 import json
-
+from django.db.models import Min
+from django.shortcuts import get_object_or_404
+from table.models import Table
 
 class MenuAPIView(APIView):
     """
     메뉴 등록 API
-    POST /api/v3/menus/
+    POST /api/v3/django/booth/menus/
     """
     permission_classes = [IsAuthenticated]
     parser_classes = [MultiPartParser, FormParser, JSONParser]
-    
     def post(self, request):
-        """메뉴 등록"""
         booth = request.user.booth
-        
         serializer = MenuSerializer(data=request.data)
-        
         if not serializer.is_valid():
             return Response({
                 "message": "입력값 유효성 검사 실패",
                 "errors": serializer.errors
             }, status=status.HTTP_400_BAD_REQUEST)
-        
-        # 메뉴 생성
         menu = MenuService.create_menu(booth, serializer.validated_data)
-        
-        # 응답 직렬화
         response_serializer = MenuSerializer(menu)
-        
         return Response({
             "message": "메뉴 등록 성공",
             "data": response_serializer.data
         }, status=status.HTTP_201_CREATED)
 
-
 class MenuDetailAPIView(APIView):
     """
     메뉴 수정/삭제 API
-    PATCH /api/v3/menus/<menu_id>/
-    DELETE /api/v3/menus/<menu_id>/
+    PATCH /api/v3/django/booth/menus/<menu_id>/
+    DELETE /api/v3/django/booth/menus/<menu_id>/
     """
     permission_classes = [IsAuthenticated]
     parser_classes = [MultiPartParser, FormParser, JSONParser]
-    
     def get_menu(self, menu_id, booth, action='modify'):
-        """
-        메뉴 조회 + 권한 검증
-        action: 'modify' (수정) 또는 'delete' (삭제)
-        """
         try:
             menu = Menu.objects.get(id=menu_id)
         except Menu.DoesNotExist:
-            if action == 'delete':
-                message = "이미 삭제되었거나 존재하지 않는 메뉴입니다."
-            else:
-                message = "수정하려는 메뉴 정보를 찾을 수 없습니다."
+            message = "수정하려는 메뉴 정보를 찾을 수 없습니다." if action == 'modify' else "이미 삭제되었거나 존재하지 않는 메뉴입니다."
             return None, Response({
                 "message": message,
                 "code": "MENU_NOT_FOUND"
             }, status=status.HTTP_404_NOT_FOUND)
-        
-        # 권한 검증: 해당 부스의 메뉴인지 확인
         if menu.booth.pk != booth.pk:
-            if action == 'delete':
-                message = "해당 메뉴를 삭제할 수 있는 권한이 없습니다."
-            else:
-                message = "해당 메뉴를 수정할 권한이 없습니다."
+            message = "해당 메뉴를 수정할 권한이 없습니다." if action == 'modify' else "해당 메뉴를 삭제할 권한이 없습니다."
             return None, Response({
                 "message": message,
                 "code": "PERMISSION_DENIED"
             }, status=status.HTTP_403_FORBIDDEN)
-        
         return menu, None
-    
     def patch(self, request, menu_id):
-        """메뉴 수정"""
         booth = request.user.booth
-        
         menu, error_response = self.get_menu(menu_id, booth)
         if error_response:
             return error_response
-        
         serializer = MenuUpdateSerializer(menu, data=request.data, partial=True, context={'request': request})
-        
         if not serializer.is_valid():
             return Response({
-                "message": "데이터 수정 형식이 올바르지 않습니다.",
+                "message": "입력값 유효성 검사 실패",
                 "errors": serializer.errors
             }, status=status.HTTP_400_BAD_REQUEST)
-        
-        # 메뉴 수정
         menu = MenuService.update_menu(menu, serializer.validated_data)
-        
-        # 응답 직렬화
         response_serializer = MenuSerializer(menu)
-        
         return Response({
             "message": "메뉴 수정 성공",
             "data": response_serializer.data
         }, status=status.HTTP_200_OK)
-    
     def delete(self, request, menu_id):
-        """메뉴 삭제"""
         booth = request.user.booth
-        
         menu, error_response = self.get_menu(menu_id, booth, action='delete')
         if error_response:
             return error_response
-        
-        # 삭제 전 menu_id 저장
         deleted_menu_id = menu.id
-        
-        # 메뉴 삭제 (이미지 파일 포함)
         MenuService.delete_menu(menu)
-        
         return Response({
             "message": "메뉴 삭제 성공",
-            "data": {
-                "menu_id": deleted_menu_id
-            }
+            "data": {"menu_id": deleted_menu_id}
         }, status=status.HTTP_200_OK)
-
 
 class SetMenuAPIView(APIView):
     """
@@ -138,56 +95,37 @@ class SetMenuAPIView(APIView):
     """
     permission_classes = [IsAuthenticated]
     parser_classes = [MultiPartParser, FormParser, JSONParser]
-    
     def post(self, request):
-        """세트메뉴 등록"""
         booth = request.user.booth
-        
-        # request.data 처리 (QueryDict → dict 변환 및 set_items JSON 파싱)
         if hasattr(request.data, 'dict'):
-            # MultiPartParser/FormParser인 경우 (QueryDict)
             data = {}
             for key in request.data:
                 if key == 'set_items':
-                    # set_items는 JSON 문자열로 들어옴
                     try:
                         data['set_items'] = json.loads(request.data.get('set_items'))
                     except json.JSONDecodeError:
                         return Response({
                             "message": "입력값 유효성 검사 실패",
-                            "errors": {
-                                "set_items": "유효하지 않은 JSON 형식입니다."
-                            }
+                            "errors": {"set_items": "유효하지 않은 JSON 형식입니다."}
                         }, status=status.HTTP_400_BAD_REQUEST)
                 elif key == 'image':
-                    # 파일은 그대로
                     data['image'] = request.data.get('image')
                 else:
-                    # 일반 필드
                     data[key] = request.data.get(key)
         else:
-            # JSONParser인 경우 (이미 dict)
             data = request.data
-        
         serializer = SetMenuSerializer(data=data)
-        
         if not serializer.is_valid():
             return Response({
                 "message": "입력값 유효성 검사 실패",
                 "errors": serializer.errors
             }, status=status.HTTP_400_BAD_REQUEST)
-        
-        # 세트메뉴 생성
         set_menu = SetMenuService.create_set_menu(booth, serializer.validated_data)
-        
-        # 응답 직렬화
         response_serializer = SetMenuSerializer(set_menu)
-        
         return Response({
             "message": "세트메뉴 등록 성공",
             "data": response_serializer.data
         }, status=status.HTTP_201_CREATED)
-
 
 class SetMenuDetailAPIView(APIView):
     """
@@ -197,48 +135,28 @@ class SetMenuDetailAPIView(APIView):
     """
     permission_classes = [IsAuthenticated]
     parser_classes = [MultiPartParser, FormParser, JSONParser]
-    
     def get_set_menu(self, set_id, booth, action='modify'):
-        """
-        세트메뉴 조회 + 권한 검증
-        action: 'modify' (수정) 또는 'delete' (삭제)
-        """
         try:
             set_menu = SetMenu.objects.get(id=set_id)
         except SetMenu.DoesNotExist:
-            if action == 'delete':
-                message = "이미 삭제되었거나 존재하지 않는 세트메뉴입니다."
-            else:
-                message = "수정하려는 세트메뉴 정보를 찾을 수 없습니다."
+            message = "수정하려는 세트메뉴 정보를 찾을 수 없습니다." if action == 'modify' else "이미 삭제되었거나 존재하지 않는 세트메뉴입니다."
             return None, Response({
                 "message": message,
                 "code": "MENU_NOT_FOUND"
             }, status=status.HTTP_404_NOT_FOUND)
-        
-        # 권한 검증: 해당 부스의 세트메뉴인지 확인
         if set_menu.booth.pk != booth.pk:
-            if action == 'delete':
-                message = "해당 세트메뉴를 삭제할 권한이 없습니다."
-            else:
-                message = "해당 세트메뉴를 수정할 권한이 없습니다."
+            message = "해당 세트메뉴를 수정할 권한이 없습니다." if action == 'modify' else "해당 세트메뉴를 삭제할 권한이 없습니다."
             return None, Response({
                 "message": message,
                 "code": "PERMISSION_DENIED"
             }, status=status.HTTP_403_FORBIDDEN)
-        
         return set_menu, None
-    
     def patch(self, request, set_id):
-        """세트메뉴 수정"""
         booth = request.user.booth
-        
         set_menu, error_response = self.get_set_menu(set_id, booth)
         if error_response:
             return error_response
-        
-        # request.data 처리 (QueryDict → dict 변환 및 set_items JSON 파싱)
         if hasattr(request.data, 'dict'):
-            # MultiPartParser/FormParser인 경우 (QueryDict)
             data = {}
             for key in request.data:
                 if key == 'set_items':
@@ -247,9 +165,7 @@ class SetMenuDetailAPIView(APIView):
                     except json.JSONDecodeError:
                         return Response({
                             "message": "데이터 수정 형식이 올바르지 않습니다.",
-                            "errors": {
-                                "set_items": "유효하지 않은 JSON 형식입니다."
-                            }
+                            "errors": {"set_items": "유효하지 않은 JSON 형식입니다."}
                         }, status=status.HTTP_400_BAD_REQUEST)
                 elif key == 'image':
                     data['image'] = request.data.get('image')
@@ -257,49 +173,215 @@ class SetMenuDetailAPIView(APIView):
                     data[key] = request.data.get(key)
         else:
             data = request.data
-        
-        serializer = SetMenuUpdateSerializer(
-            set_menu, 
-            data=data, 
-            partial=True, 
-            context={'request': request}
-        )
-        
+        serializer = SetMenuUpdateSerializer(set_menu, data=data, partial=True, context={'request': request})
         if not serializer.is_valid():
             return Response({
                 "message": "데이터 수정 형식이 올바르지 않습니다.",
                 "errors": serializer.errors
             }, status=status.HTTP_400_BAD_REQUEST)
-        
-        # 세트메뉴 수정
         set_menu = SetMenuService.update_set_menu(set_menu, serializer.validated_data)
-        
-        # 응답 직렬화
         response_serializer = SetMenuSerializer(set_menu)
-        
         return Response({
             "message": "세트메뉴 수정 성공",
             "data": response_serializer.data
         }, status=status.HTTP_200_OK)
-    
     def delete(self, request, set_id):
-        """세트메뉴 삭제"""
         booth = request.user.booth
-        
         set_menu, error_response = self.get_set_menu(set_id, booth, action='delete')
         if error_response:
             return error_response
-        
-        # 삭제 전 set_id 저장
         deleted_set_id = set_menu.id
-        
-        # 세트메뉴 삭제 (이미지 파일 + SetMenuItem CASCADE 삭제)
         SetMenuService.delete_set_menu(set_menu)
-        
         return Response({
             "message": "메뉴 삭제 성공",
-            "data": {
-                "set_id": deleted_set_id
-            }
+            "data": {"set_id": deleted_set_id}
         }, status=status.HTTP_200_OK)
+
+class BoothMenuListAPIView(APIView):
+    """
+    운영자 부스 전체 메뉴판 조회 API
+    GET /api/v3/django/booth/menus/
+    """
+    permission_classes = [IsAuthenticated]
+    def get(self, request):
+        user = request.user
+        booth = getattr(user, 'booth', None)
+        if not booth:
+            return Response({
+                "message": "부스 정보를 찾을 수 없습니다.",
+                "code": "MENU_NOT_FOUND"
+            }, status=status.HTTP_404_NOT_FOUND)
+        data = []
+        fee_id = 1000 + booth.pk
+        seat_type = booth.seat_type
+        fee_price = 0
+        fee_desc = ""
+        if seat_type == 'NO':
+            fee_price = 0
+            fee_desc = "FREE"
+        elif seat_type == 'PP':
+            fee_price = booth.seat_fee_person or 0
+            fee_desc = "인원 수"
+        elif seat_type == 'PT':
+            fee_price = booth.seat_fee_table or 0
+            fee_desc = "테이블"
+        fee_item = {
+            "id": fee_id,
+            "name": "테이블 이용료",
+            "price": fee_price,
+            "category": "FEE",
+            "description": fee_desc,
+            "image": None,
+            "stock": 9999,
+            "is_soldout": False,
+            "is_fixed": True,
+            "created_at": booth.created_at.isoformat() if hasattr(booth, 'created_at') else None
+        }
+        data.append(fee_item)
+        menus = Menu.objects.filter(booth=booth).exclude(category="FEE").order_by("id")
+        for menu in menus:
+            data.append({
+                "id": menu.pk,
+                "name": menu.name,
+                "price": int(menu.price),
+                "category": menu.category,
+                "description": menu.description or "",
+                "image": menu.image.url if menu.image else None,
+                "stock": menu.stock,
+                "is_soldout": menu.stock == 0,
+                "is_fixed": False,
+                "created_at": menu.created_at.isoformat() if hasattr(menu, 'created_at') else None
+            })
+        set_menus = SetMenu.objects.filter(booth=booth).order_by("id")
+        for setmenu in set_menus:
+            # 각 구성품별 (menu.stock // quantity) 계산
+            item_stocks = [item.menu.stock // item.quantity for item in setmenu.items.all() if item.menu.stock is not None and item.quantity > 0]
+            min_stock = min(item_stocks) if item_stocks else 0
+            is_soldout = any(item.menu.stock == 0 for item in setmenu.items.all())
+            data.append({
+                "id": setmenu.pk,
+                "name": setmenu.name,
+                "price": setmenu.price,
+                "category": "SET",
+                "description": setmenu.description or "",
+                "image": setmenu.image.url if setmenu.image else None,
+                "stock": min_stock,
+                "is_soldout": is_soldout,
+                "is_fixed": False,
+                "created_at": setmenu.created_at.isoformat() if hasattr(setmenu, 'created_at') else None
+            })
+        return Response({
+            "message": "운영자 메뉴 목록 조회 완료",
+            "booth_id": booth.pk,
+            "data": data
+        }, status=status.HTTP_200_OK)
+
+class UserMenuListAPIView(APIView):
+    """
+    사용자 메뉴판 조회 API
+    GET /api/v3/django/booth/<int:booth_id>/menu-list/?table_number=xxx
+    """
+    permission_classes = []  # 로그인 없이 접근 가능
+    def get(self, request, booth_id):
+        table_num = request.GET.get('table_num')
+        booth = get_object_or_404(Booth, pk=booth_id)
+        table_info = None
+        if table_num is not None:
+            try:
+                table_num_int = int(table_num)
+            except (ValueError, TypeError):
+                return Response({
+                    "message": "유효하지 않은 테이블 번호입니다.",
+                    "code": "TABLE_NUMBER_INVALID"
+                }, status=status.HTTP_400_BAD_REQUEST)
+            table_obj = Table.objects.filter(booth=booth, table_num=table_num_int).first()
+            if not table_obj:
+                return Response({
+                    "message": "존재하지 않는 테이블 번호입니다.",
+                    "code": "TABLE_NOT_FOUND"
+                }, status=status.HTTP_404_NOT_FOUND)
+            usage = table_obj.usages.order_by('-started_at').first()
+            table_info = {
+                "table_number": table_num_int,
+                "table_usage_id": usage.id if usage else None
+            }
+        # FEE 동적 생성
+        fee_id = 1000 + booth.pk
+        seat_type = booth.seat_type
+        fee_price = 0
+        fee_desc = ""
+        if seat_type == 'NO':
+            fee_price = 0
+            fee_desc = "FREE"
+        elif seat_type == 'PP':
+            fee_price = booth.seat_fee_person or 0
+            fee_desc = "인원 수에 맞춰 주문해 주세요."
+        elif seat_type == 'PT':
+            fee_price = booth.seat_fee_table or 0
+            fee_desc = "테이블 기준 1회 주문이 필요해요"
+        fee_data = [{
+            "id": fee_id,
+            "name": "테이블 이용료",
+            "price": fee_price,
+            "description": fee_desc,
+            "image": None,
+            "is_soldout": False
+        }]
+        # SET
+        set_menus = SetMenu.objects.filter(booth=booth).order_by('-price')
+        set_data = []
+        for setmenu in set_menus:
+            origin_price = sum([item.menu.price * item.quantity for item in setmenu.items.all()])
+            discount_rate = round((origin_price - setmenu.price) / origin_price * 100, 1) if origin_price > 0 else 0.0
+            is_soldout = any(item.menu.stock == 0 for item in setmenu.items.all())
+            set_data.append({
+                "id": setmenu.pk,
+                "name": setmenu.name,
+                "origin_price": int(origin_price),
+                "price": setmenu.price,
+                "discount_rate": discount_rate,
+                "description": setmenu.description or "",
+                "image": setmenu.image.url if setmenu.image else None,
+                "is_soldout": is_soldout
+            })
+        set_data.sort(key=lambda x: x['price'], reverse=True)
+        # MENU
+        menu_data = []
+        menus = Menu.objects.filter(booth=booth, category="MENU").order_by('-price')
+        for menu in menus:
+            menu_data.append({
+                "id": menu.pk,
+                "name": menu.name,
+                "price": int(menu.price),
+                "description": menu.description or "",
+                "image": menu.image.url if menu.image else None,
+                "is_soldout": menu.stock == 0
+            })
+        # DRINK
+        drink_data = []
+        drinks = Menu.objects.filter(booth=booth, category="DRINK").order_by('-price')
+        for drink in drinks:
+            drink_data.append({
+                "id": drink.pk,
+                "name": drink.name,
+                "price": int(drink.price),
+                "description": drink.description or "",
+                "image": drink.image.url if drink.image else None,
+                "is_soldout": drink.stock == 0
+            })
+        resp = {
+            "message": "메뉴판 조회 완료",
+            "booth_id": booth.pk,
+            "booth_name": booth.name,
+            "seat_type": seat_type,
+            "data": {
+                "FEE": fee_data,
+                "SET": set_data,
+                "MENU": menu_data,
+                "DRINK": drink_data
+            }
+        }
+        if table_info:
+            resp["table_info"] = table_info
+        return Response(resp, status=status.HTTP_200_OK)
 


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
# [Feat] 사용자/운영자 메뉴판 조회 API
## 🔍 What is the PR?

- 사용자 메뉴판 조회 API(UserMenuListAPIView) 구현 및 테스트 통합
- 운영자 메뉴판 조회 API(BoothMenuListAPIView) 구현
- table_num 파라미터 기반 동적 table_info 응답
- FEE(테이블 이용료) 동적 생성 및 응답 구조 일원화
- API 파라미터/응답/유효성검사 명확화
- 통합 테스트 코드 추가 및 기존 tests.py에 병합

## 📍 PR Point

<!-- 나 이 부분 찢었다~! -->

- 사용자/운영자 메뉴판 조회 API 완전 일원화 및 robust한 유효성검사
- table_num 파라미터 유무에 따라 table_info 포함/미포함 자동 처리
- 테스트 코드까지 완벽하게 통합 및 자동 검증

## 📢 Notices

- FEE(테이블 이용료)는 DB 저장 없이 동적 생성, 부스 생성/수정 시에는 DB에 저장

## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #62 
<!-- - ex) #3 -->