### PR TITLE
♻️  [Refactor] #50 - JWT username claim 관련 함수 삭제 및 booth_id으로  변수명통일

### DIFF
--- a/spring/src/main/java/com/example/spring/config/JwtUtil.java
+++ b/spring/src/main/java/com/example/spring/config/JwtUtil.java
@@ -33,13 +33,13 @@ public class JwtUtil {
     /**
      * Access Token 생성
      */
-    public String generateAccessToken(Long userId, String username) {
+    public String generateAccessToken(Long boothId, String username) {
         Date now = new Date();
         Date expiry = new Date(now.getTime() + jwtProperties.getAccessTokenExpiration());
 
         return Jwts.builder()
-                .subject(String.valueOf(userId))
-                .claim("user_id", userId)
+                .subject(String.valueOf(boothId))
+                .claim("booth_id", boothId)
                 .claim("username", username)
                 .claim("token_type", "access")
                 .issuedAt(now)
@@ -51,13 +51,13 @@ public class JwtUtil {
     /**
      * Refresh Token 생성
      */
-    public String generateRefreshToken(Long userId, String username) {
+    public String generateRefreshToken(Long boothId, String username) {
         Date now = new Date();
         Date expiry = new Date(now.getTime() + jwtProperties.getRefreshTokenExpiration());
 
         return Jwts.builder()
-                .subject(String.valueOf(userId))
-                .claim("user_id", userId)
+                .subject(String.valueOf(boothId))
+                .claim("booth_id", boothId)
                 .claim("username", username)
                 .claim("token_type", "refresh")
                 .issuedAt(now)
@@ -80,25 +80,19 @@ public class JwtUtil {
     /**
      * 토큰에서 사용자 ID 추출
      */
-    public Long getUserIdFromToken(String token) {
+    public Long getBoothIdFromToken(String token) {
         Claims claims = parseClaims(token);
-        Object userIdObj = claims.get("user_id");
-        if (userIdObj instanceof String) {
-            return Long.valueOf((String) userIdObj);
-        } else if (userIdObj instanceof Number) {
-            return ((Number) userIdObj).longValue();
+        Object boothIdObj = claims.get("user_id"); // 실제 claim 이름은 user_id
+        if (boothIdObj instanceof String) {
+            return Long.valueOf((String) boothIdObj);
+        } else if (boothIdObj instanceof Number) {
+            return ((Number) boothIdObj).longValue();
         } else {
-            throw new IllegalArgumentException("user_id claim 타입 변환 실패: " + userIdObj);
+            throw new IllegalArgumentException("booth_id claim 타입 변환 실패: " + boothIdObj);
         }
     }
 
-    /**
-     * 토큰에서 username 추출
-     */
-    public String getUsernameFromToken(String token) {
-        Claims claims = parseClaims(token);
-        return claims.get("username", String.class);
-    }
+    
 
     /**
      * 토큰 유효성 검증

--- a/spring/src/main/java/com/example/spring/controller/test/TestController.java
+++ b/spring/src/main/java/com/example/spring/controller/test/TestController.java
@@ -4,10 +4,8 @@ import com.example.spring.dto.test.request.TestCreateRequest;
 import com.example.spring.dto.test.response.TestResponse;
 import com.example.spring.service.test.TestService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import jakarta.servlet.http.HttpServletRequest;
 import com.example.spring.config.JwtUtil;
 import com.example.spring.config.CookieUtil;
 
@@ -37,16 +35,19 @@ public class TestController {
 
     // JWT 디코드 테스트 API
     @GetMapping("/spring-test/decode")
-public ResponseEntity<?> decodeJwt(jakarta.servlet.http.HttpServletRequest request) {
-    String accessToken = cookieUtil.getAccessTokenFromCookies(request.getCookies());
-    if (accessToken == null) {
-        return ResponseEntity.status(401).body("access_token 쿠키 없음");
+    public ResponseEntity<?> decodeJwt(jakarta.servlet.http.HttpServletRequest request) {
+        String accessToken = cookieUtil.getAccessTokenFromCookies(request.getCookies());
+        if (accessToken == null) {
+            return ResponseEntity.status(401).body("access_token 쿠키 없음");
+        }
+        try {
+            Long boothId = jwtUtil.getBoothIdFromToken(accessToken);
+            return ResponseEntity.ok(java.util.Map.of(
+                "booth_id", boothId
+        
+            ));
+        } catch (Exception e) {
+            return ResponseEntity.status(400).body("JWT 디코드 실패: " + e.getMessage());
+        }
     }
-    try {
-        Long userId = jwtUtil.getUserIdFromToken(accessToken);
-        return ResponseEntity.ok(java.util.Map.of("user_id", userId));
-    } catch (Exception e) {
-        return ResponseEntity.status(400).body("JWT 디코드 실패: " + e.getMessage());
-    }
-}
 }


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->
JWT username claim 관련 함수 삭제 및 booth_id으로  변수명통일

기존함수에서 토큰 디코드로 username은 못얻어오는데 구현되어있어서 함수삭제, jwt토큰 decode시 개발 편의를 위해 booth_id로 반환하는 변수명 변경 

## 📢 Notices

 <!-- 공용으로 사용하는(Extension) 부분에 대한 설명 -->

@taejun0 api개발중 getUserIdFromToken 함수를 사용한것이 있다면 이름이 getBoothIDFomToken으로 변경되었으니 맞추어 변경 부탁드립니다. 

## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #50 
<!-- - ex) #3 -->