### PR TITLE
✨ [Feat] #70 - Spring redis pub/sub연동기능 개발

### DIFF
--- a/.idea/modules/spring.main.iml
+++ b/.idea/modules/spring.main.iml
@@ -4,6 +4,11 @@
     <facet external-system-id="GRADLE" type="web" name="Web">
       <configuration>
         <webroots />
+        <sourceRoots>
+          <root url="file://$MODULE_DIR$/../../spring/build/generated/sources/annotationProcessor/java/main" />
+          <root url="file://$MODULE_DIR$/../../spring/src/main/java" />
+          <root url="file://$MODULE_DIR$/../../spring/src/main/resources" />
+        </sourceRoots>
       </configuration>
     </facet>
   </component>
@@ -23,6 +28,7 @@
     <orderEntry type="library" name="Gradle: org.springframework.boot:spring-boot-starter-data-jpa:3.5.4" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework.boot:spring-boot-starter-web:3.5.4" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework.boot:spring-boot-starter-security:3.5.4" level="project" />
+    <orderEntry type="library" name="Gradle: org.springframework.boot:spring-boot-starter-data-redis:3.5.4" level="project" />
     <orderEntry type="library" name="Gradle: io.jsonwebtoken:jjwt-api:0.12.6" level="project" />
     <orderEntry type="library" name="Gradle: com.google.genai:google-genai:1.11.0" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework.boot:spring-boot-starter-jdbc:3.5.4" level="project" />
@@ -37,6 +43,8 @@
     <orderEntry type="library" name="Gradle: org.springframework.security:spring-security-web:6.5.2" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework.security:spring-security-config:6.5.2" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework:spring-aop:6.2.9" level="project" />
+    <orderEntry type="library" name="Gradle: org.springframework.data:spring-data-redis:3.5.2" level="project" />
+    <orderEntry type="library" name="Gradle: io.lettuce:lettuce-core:6.6.0.RELEASE" level="project" />
     <orderEntry type="library" name="Gradle: com.google.auth:google-auth-library-oauth2-http:1.33.0" level="project" />
     <orderEntry type="library" name="Gradle: org.apache.httpcomponents:httpclient:4.5.14" level="project" />
     <orderEntry type="library" name="Gradle: com.google.auto.value:auto-value:1.11.0" level="project" />
@@ -73,6 +81,14 @@
     <orderEntry type="library" name="Gradle: org.springframework:spring-expression:6.2.9" level="project" />
     <orderEntry type="library" name="Gradle: io.micrometer:micrometer-observation:1.15.2" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework.security:spring-security-core:6.5.2" level="project" />
+    <orderEntry type="library" name="Gradle: org.springframework.data:spring-data-keyvalue:3.5.2" level="project" />
+    <orderEntry type="library" name="Gradle: org.springframework:spring-context-support:6.2.9" level="project" />
+    <orderEntry type="library" name="Gradle: org.springframework:spring-oxm:6.2.9" level="project" />
+    <orderEntry type="library" name="Gradle: redis.clients.authentication:redis-authx-core:0.1.1-beta2" level="project" />
+    <orderEntry type="library" name="Gradle: io.netty:netty-handler:4.1.123.Final" level="project" />
+    <orderEntry type="library" name="Gradle: io.netty:netty-transport:4.1.123.Final" level="project" />
+    <orderEntry type="library" name="Gradle: io.netty:netty-common:4.1.123.Final" level="project" />
+    <orderEntry type="library" name="Gradle: io.projectreactor:reactor-core:3.7.8" level="project" />
     <orderEntry type="library" name="Gradle: com.google.http-client:google-http-client-gson:1.46.2" level="project" />
     <orderEntry type="library" name="Gradle: com.google.http-client:google-http-client:1.46.2" level="project" />
     <orderEntry type="library" name="Gradle: com.google.auto.value:auto-value-annotations:1.11.0" level="project" />
@@ -96,6 +112,11 @@
     <orderEntry type="library" name="Gradle: org.springframework:spring-jcl:6.2.9" level="project" />
     <orderEntry type="library" name="Gradle: io.micrometer:micrometer-commons:1.15.2" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework.security:spring-security-crypto:6.5.2" level="project" />
+    <orderEntry type="library" name="Gradle: io.netty:netty-transport-native-unix-common:4.1.123.Final" level="project" />
+    <orderEntry type="library" name="Gradle: io.netty:netty-codec:4.1.123.Final" level="project" />
+    <orderEntry type="library" name="Gradle: io.netty:netty-resolver:4.1.123.Final" level="project" />
+    <orderEntry type="library" name="Gradle: io.netty:netty-buffer:4.1.123.Final" level="project" />
+    <orderEntry type="library" name="Gradle: org.reactivestreams:reactive-streams:1.0.4" level="project" />
     <orderEntry type="library" name="Gradle: io.opencensus:opencensus-contrib-http-util:0.31.1" level="project" />
     <orderEntry type="library" name="Gradle: io.opencensus:opencensus-api:0.31.1" level="project" />
     <orderEntry type="library" name="Gradle: io.grpc:grpc-context:1.70.0" level="project" />

--- a/.idea/modules/spring.test.iml
+++ b/.idea/modules/spring.test.iml
@@ -19,6 +19,7 @@
     <orderEntry type="library" name="Gradle: org.springframework.boot:spring-boot-starter-data-jpa:3.5.4" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework.boot:spring-boot-starter-web:3.5.4" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework.boot:spring-boot-starter-security:3.5.4" level="project" />
+    <orderEntry type="library" name="Gradle: org.springframework.boot:spring-boot-starter-data-redis:3.5.4" level="project" />
     <orderEntry type="library" name="Gradle: io.jsonwebtoken:jjwt-api:0.12.6" level="project" />
     <orderEntry type="library" name="Gradle: com.google.genai:google-genai:1.11.0" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework.boot:spring-boot-starter-test:3.5.4" level="project" />
@@ -35,6 +36,8 @@
     <orderEntry type="library" name="Gradle: org.springframework.security:spring-security-web:6.5.2" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework.security:spring-security-config:6.5.2" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework:spring-aop:6.2.9" level="project" />
+    <orderEntry type="library" name="Gradle: org.springframework.data:spring-data-redis:3.5.2" level="project" />
+    <orderEntry type="library" name="Gradle: io.lettuce:lettuce-core:6.6.0.RELEASE" level="project" />
     <orderEntry type="library" name="Gradle: com.google.auth:google-auth-library-oauth2-http:1.33.0" level="project" />
     <orderEntry type="library" name="Gradle: org.apache.httpcomponents:httpclient:4.5.14" level="project" />
     <orderEntry type="library" name="Gradle: com.google.auto.value:auto-value:1.11.0" level="project" />
@@ -85,6 +88,14 @@
     <orderEntry type="library" name="Gradle: org.apache.tomcat.embed:tomcat-embed-el:10.1.43" level="project" />
     <orderEntry type="library" name="Gradle: org.springframework:spring-expression:6.2.9" level="project" />
     <orderEntry type="library" name="Gradle: io.micrometer:micrometer-observation:1.15.2" level="project" />
+    <orderEntry type="library" name="Gradle: org.springframework.data:spring-data-keyvalue:3.5.2" level="project" />
+    <orderEntry type="library" name="Gradle: org.springframework:spring-context-support:6.2.9" level="project" />
+    <orderEntry type="library" name="Gradle: org.springframework:spring-oxm:6.2.9" level="project" />
+    <orderEntry type="library" name="Gradle: redis.clients.authentication:redis-authx-core:0.1.1-beta2" level="project" />
+    <orderEntry type="library" name="Gradle: io.netty:netty-handler:4.1.123.Final" level="project" />
+    <orderEntry type="library" name="Gradle: io.netty:netty-transport:4.1.123.Final" level="project" />
+    <orderEntry type="library" name="Gradle: io.netty:netty-common:4.1.123.Final" level="project" />
+    <orderEntry type="library" name="Gradle: io.projectreactor:reactor-core:3.7.8" level="project" />
     <orderEntry type="library" name="Gradle: com.google.http-client:google-http-client-gson:1.46.2" level="project" />
     <orderEntry type="library" name="Gradle: com.google.http-client:google-http-client:1.46.2" level="project" />
     <orderEntry type="library" name="Gradle: com.google.auto.value:auto-value-annotations:1.11.0" level="project" />
@@ -115,6 +126,11 @@
     <orderEntry type="library" name="Gradle: org.apache.logging.log4j:log4j-to-slf4j:2.24.3" level="project" />
     <orderEntry type="library" name="Gradle: org.slf4j:jul-to-slf4j:2.0.17" level="project" />
     <orderEntry type="library" name="Gradle: io.micrometer:micrometer-commons:1.15.2" level="project" />
+    <orderEntry type="library" name="Gradle: io.netty:netty-transport-native-unix-common:4.1.123.Final" level="project" />
+    <orderEntry type="library" name="Gradle: io.netty:netty-codec:4.1.123.Final" level="project" />
+    <orderEntry type="library" name="Gradle: io.netty:netty-resolver:4.1.123.Final" level="project" />
+    <orderEntry type="library" name="Gradle: io.netty:netty-buffer:4.1.123.Final" level="project" />
+    <orderEntry type="library" name="Gradle: org.reactivestreams:reactive-streams:1.0.4" level="project" />
     <orderEntry type="library" name="Gradle: io.opencensus:opencensus-contrib-http-util:0.31.1" level="project" />
     <orderEntry type="library" name="Gradle: io.opencensus:opencensus-api:0.31.1" level="project" />
     <orderEntry type="library" name="Gradle: io.grpc:grpc-context:1.70.0" level="project" />

--- a/spring/build.gradle
+++ b/spring/build.gradle
@@ -28,6 +28,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
@@ -37,7 +40,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 //	runtimeOnly 'com.mysql:mysql-connector-j'
-    runtimeOnly 'org.postgresql:postgresql'
+	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/spring/src/main/java/com/example/spring/config/RedisConfig.java
+++ b/spring/src/main/java/com/example/spring/config/RedisConfig.java
@@ -1,0 +1,28 @@
+package com.example.spring.config;
+
+import com.example.spring.redis.RedisSubscriber;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(
+            RedisConnectionFactory connectionFactory,
+            RedisSubscriber redisSubscriber) {
+
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+
+        // 예시 채널명: 실제 운영 채널명에 맞게 수정 필요
+        container.addMessageListener(redisSubscriber, new ChannelTopic("booth:1:order:new"));
+        container.addMessageListener(redisSubscriber, new ChannelTopic("booth:1:staffcall:newcall"));
+        container.addMessageListener(redisSubscriber, new ChannelTopic("test:1:testname:moving"));
+
+        return container;
+    }
+}

--- a/spring/src/main/java/com/example/spring/controller/test/RedisTestController.java
+++ b/spring/src/main/java/com/example/spring/controller/test/RedisTestController.java
@@ -1,0 +1,38 @@
+package com.example.spring.controller.test;
+
+import com.example.spring.event.RedisMessageEvent;
+import com.example.spring.service.test.RedisPublishService;
+import org.springframework.context.event.EventListener;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RestController
+@RequestMapping("/redis")
+public class RedisTestController {
+
+    private final RedisPublishService redisPublishService;
+    private final List<RedisMessageEvent> receivedMessages = new ArrayList<>();
+
+    public RedisTestController(RedisPublishService redisPublishService) {
+        this.redisPublishService = redisPublishService;
+    }
+
+    @EventListener
+    public void handleRedisMessage(RedisMessageEvent event) {
+        receivedMessages.add(event);
+    }
+
+    @GetMapping("/messages")
+    public ResponseEntity<List<RedisMessageEvent>> getMessages() {
+        return ResponseEntity.ok(receivedMessages);
+    }
+
+    @PostMapping("/publish")
+    public String publish(@RequestParam String channel, @RequestBody String message) {
+        redisPublishService.publish(channel, message);
+        return "published";
+    }
+}

--- a/spring/src/main/java/com/example/spring/event/RedisMessageEvent.java
+++ b/spring/src/main/java/com/example/spring/event/RedisMessageEvent.java
@@ -1,0 +1,14 @@
+package com.example.spring.event;
+
+public class RedisMessageEvent {
+    private final String channel;
+    private final String message;
+
+    public RedisMessageEvent(String channel, String message) {
+        this.channel = channel;
+        this.message = message;
+    }
+
+    public String getChannel() { return channel; }
+    public String getMessage() { return message; }
+}

--- a/spring/src/main/java/com/example/spring/redis/RedisSubscriber.java
+++ b/spring/src/main/java/com/example/spring/redis/RedisSubscriber.java
@@ -1,0 +1,24 @@
+package com.example.spring.redis;
+
+import com.example.spring.event.RedisMessageEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RedisSubscriber implements MessageListener {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    public RedisSubscriber(ApplicationEventPublisher eventPublisher) {
+        this.eventPublisher = eventPublisher;
+    }
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        String publishedMessage = new String(message.getBody());
+        String channel = new String(message.getChannel());
+        eventPublisher.publishEvent(new RedisMessageEvent(channel, publishedMessage));
+    }
+}

--- a/spring/src/main/java/com/example/spring/service/test/RedisPublishService.java
+++ b/spring/src/main/java/com/example/spring/service/test/RedisPublishService.java
@@ -1,0 +1,17 @@
+package com.example.spring.service.test;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RedisPublishService {
+    private final StringRedisTemplate redisTemplate;
+
+    public RedisPublishService(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void publish(String channel, String message) {
+        redisTemplate.convertAndSend(channel, message);
+    }
+}

--- a/spring/src/main/resources/application.yml
+++ b/spring/src/main/resources/application.yml
@@ -58,6 +58,12 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+  # Redis 설정을 추가
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}
 
 ---
 # ==================================================================


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->

Spring Redis Pub/Sub 연동 기능 개발했습니다. 

- Spring Boot에서 Redis Pub/Sub 구조 구현
- 구독 채널 및 메시지 리스너 설정 (RedisConfig, RedisSubscriber)
- Redis 메시지 이벤트 객체 정의 (RedisMessageEvent)
- 테스트용 publish/subscribe REST API 및 서비스 구현
- Postman/redis-cli로 메시지 발행 및 수신 테스트 가능
- Django와 실시간 상태 동기화 및 연동을 위한 기반 코드 제공


## 📢 Notices

 <!-- 공용으로 사용하는(Extension) 부분에 대한 설명 -->

@gn00py48  @taejun0  
인텔리제이 환경변수에 redis관련 변수 입력하고 테스트해주세요 

RedisConfig.java 에서 채널추가하고 

웹소켓 코드에서 원하는 서비스/컨트롤러에서 아래처럼 이벤트 리스너 구현하시면됩니다. 
```
@Service
public class MyService {
    @EventListener
    public void handleRedisMessage(RedisMessageEvent event) {
        // event.getChannel(), event.getMessage() 활용
    }
}

```
## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #70 
<!-- - ex) #3 -->