### PR TITLE
🐛 [Fix] #87 - redis config spring접두사 추가, 발행용채널과 구독용채널구분

### DIFF
--- a/spring/src/main/java/com/example/spring/config/RedisConfig.java
+++ b/spring/src/main/java/com/example/spring/config/RedisConfig.java
@@ -18,10 +18,28 @@ public class RedisConfig {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(connectionFactory);
 
-        // 예시 채널명: 실제 운영 채널명에 맞게 수정 필요
-        container.addMessageListener(redisSubscriber, new ChannelTopic("booth:1:order:new"));
-        container.addMessageListener(redisSubscriber, new ChannelTopic("booth:1:staffcall:newcall"));
-        container.addMessageListener(redisSubscriber, new ChannelTopic("test:1:testname:moving"));
+        // [Spring → Django] 발행용 채널명 리스트 (spring: 접두사 자동 추가)
+        String[] springPublishChannels = {
+            "booth:*:order:*",
+            "booth:*:staffcall:*"
+            
+        };
+
+        // [Django → Spring] 구독용 채널명 리스트 (django: 접두사 자동 추가)
+        String[] djangoSubscribeChannels = {
+            "booth:*:order:*",
+            "booth:*:staffcall:*"
+        };
+
+        // spring: 채널은 발행용이지만, 필요시 구독도 가능
+        for (String channel : springPublishChannels) {
+            container.addMessageListener(redisSubscriber, new ChannelTopic("spring:" + channel));
+        }
+
+        // django: 채널은 장고에서 발행한 메시지 구독 (접두사 자동 추가)
+        for (String channel : djangoSubscribeChannels) {
+            container.addMessageListener(redisSubscriber, new ChannelTopic("django:" + channel));
+        }
 
         return container;
     }

--- a/spring/src/main/java/com/example/spring/redis/RedisSubscriber.java
+++ b/spring/src/main/java/com/example/spring/redis/RedisSubscriber.java
@@ -15,10 +15,11 @@ public class RedisSubscriber implements MessageListener {
         this.eventPublisher = eventPublisher;
     }
 
-    @Override
-    public void onMessage(Message message, byte[] pattern) {
-        String publishedMessage = new String(message.getBody());
-        String channel = new String(message.getChannel());
-        eventPublisher.publishEvent(new RedisMessageEvent(channel, publishedMessage));
-    }
+@Override
+public void onMessage(Message message, byte[] pattern) {
+    String publishedMessage = new String(message.getBody());
+    String channel = new String(message.getChannel());
+    System.out.println("[구독 패턴] " + channel + " → 데이터: " + publishedMessage);
+    eventPublisher.publishEvent(new RedisMessageEvent(channel, publishedMessage));
+}
 }


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->
발행용채널과 구독용채널 구분이 없으니 redis에서 무한순환되는 문제가 있어 해결했습니다. 
발행용채널에는 spring:접두사가 자동으로 붙도록하였고 구독용채널에는 django:가 자동으로 붙게해놨으니 구독하거나 발행할 채널을 추가하고자 한다면 redis config에 적절히 추가해서 사용하시면됩니다. 

RedisSubscriber.java에 로그를추가해서 장고로부터 redis메세지가 오면 로그로도 보이게해놨습니다! 


## 📢 Notices

 <!-- 공용으로 사용하는(Extension) 부분에 대한 설명 -->
RedisConfig의 아래부분에 스프링에서 장고로 보낼것은 springPublishChannels에 채널명추가하면 됩니다 지금 order와 staffcall은 와일드카드로 추가해놨습니다. 
```

        // [Spring → Django] 발행용 채널명 리스트 (spring: 접두사 자동 추가)
        String[] springPublishChannels = {
            "booth:*:order:*",
            "booth:*:staffcall:*"
            
        };

        // [Django → Spring] 구독용 채널명 리스트 (django: 접두사 자동 추가)
        String[] djangoSubscribeChannels = {
            "booth:*:order:*",
            "booth:*:staffcall:*"
        };
```
## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #87 
<!-- - ex) #3 -->