### PR TITLE
🐛 [Fix] - cart -> order 주문 확정 트리거 / TTL 복구 관련

### DIFF
--- a/django/cart/services.py
+++ b/django/cart/services.py
@@ -4,8 +4,10 @@ from django.db.models import F, Sum, Case, When, IntegerField
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 
+from booth.models import *
 from table.models import *
 from menu.models import *
+from order.models import *
 from .models import *
 
 PENDING_TTL_MINUTES = 3
@@ -44,9 +46,9 @@ def _sync_item_prices_to_latest(cart: Cart) -> None:
         )
     )
 
+
 def recalc_cart_price(cart: Cart) -> int:
     _sync_item_prices_to_latest(cart)
-
     total = cart.items.aggregate(s=Sum(F("quantity") * F("price_at_cart")))["s"] or 0
     cart.cart_price = int(total)
     cart.save(update_fields=["cart_price"])
@@ -91,125 +93,195 @@ def get_or_create_cart_by_table_usage(table_usage_id: int) -> Cart:
     return cart
 
 
+def _calc_discount(subtotal: int, discount_type: str, discount_value) -> int:
+    # 추가
+    # 결제 확정 시점(Order 생성)에 '할인액/결제액'을 확정해야 해서 계산 필요
+    if subtotal <= 0:
+        return 0
+    if discount_type == "RATE":
+        # discount_value: Decimal(0.10) 같은 값
+        amt = int(subtotal * float(discount_value))
+        return max(0, min(subtotal, amt))
+    # AMOUNT
+    amt = int(discount_value)
+    return max(0, min(subtotal, amt))
+
+
 @transaction.atomic
-def add_to_cart(*, table_usage_id: int, type: str, menu_id: int | None, set_menu_id: int | None, quantity: int):
+def finalize_payment_and_rotate_cart(*, table_usage_id: int) -> Cart:
+
+    # 추가
+    # 운영자 입금 확인(결제 확정) 시점에 호출되는 '최종 확정 처리' 훅
+    # 여기서 주문 생성/재고 차감/매출 반영/쿠폰 used 처리까지 한 트랜잭션으로 묶음
+    
     cart = get_or_create_cart_by_table_usage(table_usage_id)
 
-    if cart.status == Cart.Status.PENDING:
-        raise CartError("결제 진행 중에는 장바구니를 수정할 수 없습니다.", "CART_PENDING", status_code=409)
-    if cart.status == Cart.Status.ORDERED:
-        raise CartError("이미 주문된 장바구니입니다.", "CART_ORDERED", status_code=409)
+    if cart.status != Cart.Status.PENDING:
+        raise CartError(
+            "결제 진행 중인(PENDING) 상태에서만 확정할 수 있습니다.",
+            "CART_NOT_PENDING",
+            status_code=409,
+        )
 
-    if quantity < 1:
-        raise CartError("quantity는 1 이상이어야 합니다.", "VALIDATION_ERROR", status_code=400)
+    # 1) 최신 가격 동기화 + subtotal 확정
+    subtotal = recalc_cart_price(cart)
 
-    if type == "menu":
-        menu = get_object_or_404(Menu, id=menu_id)
+    # 2) 재고 재검증 + (동시성) 관련 메뉴 row 잠금
+    #    결제 확정 직전에 재고가 바뀌었을 수 있으니 마지막 가드 필요
+    #    그리고 이후 stock 차감이 들어가므로 select_for_update로 잠그려고 함 !!!!!!!!!!
+    cart_items = list(cart.items.select_related("menu", "setmenu"))
 
-        item = CartItem.objects.select_for_update().filter(cart=cart, menu=menu, setmenu__isnull=True).first()
-        new_qty = quantity + (item.quantity if item else 0)
-
-        _validate_menu_stock(menu, new_qty)
-
-        unit_price = int(menu.price)
-        if item:
-            item.quantity = new_qty
-            item.price_at_cart = unit_price
-            item.save(update_fields=["quantity", "price_at_cart"])
-        else:
-            item = CartItem.objects.create(cart=cart, menu=menu, quantity=quantity, price_at_cart=unit_price)
-
-    elif type == "setmenu":
-        setmenu = get_object_or_404(SetMenu, id=set_menu_id)
-
-        item = CartItem.objects.select_for_update().filter(cart=cart, setmenu=setmenu, menu__isnull=True).first()
-        new_qty = quantity + (item.quantity if item else 0)
-
-        _validate_setmenu_stock(setmenu, new_qty)
-
-        unit_price = int(setmenu.price)
-        if item:
-            item.quantity = new_qty
-            item.price_at_cart = unit_price
-            item.save(update_fields=["quantity", "price_at_cart"])
-        else:
-            item = CartItem.objects.create(cart=cart, setmenu=setmenu, quantity=quantity, price_at_cart=unit_price)
-
+    # 단일 메뉴 잠금
+    menu_ids = [it.menu_id for it in cart_items if it.menu_id]
+    if menu_ids:
+        locked_menus = {m.id: m for m in Menu.objects.select_for_update().filter(id__in=menu_ids)}
     else:
-        raise CartError("type은 menu 또는 setmenu 여야 합니다.", "VALIDATION_ERROR", status_code=400)
+        locked_menus = {}
 
-    recalc_cart_price(cart)
-    return cart, item
+    # 세트 구성품 메뉴 잠금
+    setmenu_ids = [it.setmenu_id for it in cart_items if it.setmenu_id]
+    set_components = {}
+    if setmenu_ids:
+        comps = (
+            SetMenuItem.objects.select_related("menu")
+            .select_for_update()
+            .filter(set_menu_id__in=setmenu_ids)
+        )
+        for comp in comps:
+            set_components.setdefault(comp.set_menu_id, []).append(comp)
 
+        comp_menu_ids = list({comp.menu_id for comp in comps})
+        if comp_menu_ids:
+            for m in Menu.objects.select_for_update().filter(id__in=comp_menu_ids):
+                locked_menus[m.id] = m
 
-@transaction.atomic
-def update_item_quantity(*, table_usage_id: int, cart_item_id: int, quantity: int):
-    cart = get_or_create_cart_by_table_usage(table_usage_id)
-
-    if cart.status != Cart.Status.ACTIVE:
-        raise CartError("active 상태에서만 수정할 수 있습니다.", "CART_NOT_ACTIVE", status_code=409)
-
-    item = CartItem.objects.select_for_update().get(id=cart_item_id, cart=cart)
-
-    if quantity == 0:
-        item.delete()
-        recalc_cart_price(cart)
-        return cart, None
-
-    if item.menu_id:
-        _validate_menu_stock(item.menu, quantity)
-        item.price_at_cart = int(item.menu.price)
-    else:
-        _validate_setmenu_stock(item.setmenu, quantity)
-        item.price_at_cart = int(item.setmenu.price)
-
-    item.quantity = quantity
-    item.save(update_fields=["quantity", "price_at_cart"])
-
-    recalc_cart_price(cart)
-    return cart, item
-
-
-@transaction.atomic
-def delete_item(*, table_usage_id: int, cart_item_id: int):
-    cart = get_or_create_cart_by_table_usage(table_usage_id)
-
-    if cart.status != Cart.Status.ACTIVE:
-        raise CartError("active 상태에서만 삭제할 수 있습니다.", "CART_NOT_ACTIVE", status_code=409)
-
-    CartItem.objects.filter(id=cart_item_id, cart=cart).delete()
-    recalc_cart_price(cart)
-    return cart
-
-
-@transaction.atomic
-def enter_payment_info(*, table_usage_id: int):
-    cart = get_or_create_cart_by_table_usage(table_usage_id)
-
-    if cart.status == Cart.Status.PENDING:
-        raise CartError("이미 결제 진행 중입니다.", "CART_PENDING", status_code=409)
-    if cart.status != Cart.Status.ACTIVE:
-        raise CartError("active 상태에서만 결제를 시작할 수 있습니다.", "CART_NOT_ACTIVE", status_code=409)
-
-    recalc_cart_price(cart)
-
-    for it in cart.items.select_related("menu", "setmenu"):
+    for it in cart_items:
         if it.menu_id:
-            _validate_menu_stock(it.menu, it.quantity)
+            menu = locked_menus[it.menu_id]
+            _validate_menu_stock(menu, it.quantity)
         else:
-            _validate_setmenu_stock(it.setmenu, it.quantity)
+            comps = set_components.get(it.setmenu_id, [])
+            if not comps:
+                raise CartError("세트 구성 정보가 없습니다.", "SETMENU_INVALID", status_code=400)
 
-    cart.status = Cart.Status.PENDING
-    cart.pending_expires_at = timezone.now() + timedelta(minutes=PENDING_TTL_MINUTES)
-    cart.save(update_fields=["status", "pending_expires_at"])
+            for comp in comps:
+                menu = locked_menus[comp.menu_id]
+                required = it.quantity * comp.quantity
+                _validate_menu_stock(menu, required)
 
+    # 3) 쿠폰(예약) 확인 + 결제액 확정 + used_at 최종 처리
+    #    apply/cancel은 예약만. 확정(주문 생성) 시점에만 used_at을 찍어야 함.
+    discount_total = 0
+    applied_code = None
+    applied_coupon = None
+
+    try:
+        from coupon.models import CartCouponApply  # 순환 import 최소화: 함수 내부 import
+        applied = (
+            CartCouponApply.objects.select_for_update()
+            .filter(cart=cart, round=cart.round)
+            .select_related("coupon_code", "coupon_code__coupon")
+            .first()
+        )
+        if applied:
+            applied_code = applied.coupon_code
+            applied_coupon = applied_code.coupon
+
+            # 이미 used면(다른 주문에서 확정된 코드) 충돌 처리
+            if applied_code.used_at is not None:
+                raise CartError(
+                    "이미 사용된 쿠폰 코드입니다.",
+                    "COUPON_CODE_USED",
+                    status_code=409,
+                )
+
+            discount_total = _calc_discount(subtotal, applied_coupon.discount_type, applied_coupon.discount_value)
+
+            # 결제 확정 시점에만 used_at 기록
+            applied_code.used_at = timezone.now()
+            applied_code.save(update_fields=["used_at"])
+    except CartError:
+        raise
+    except Exception:
+        pass
+
+    order_price = subtotal - discount_total
+
+    # 4) Order 생성 + OrderItem 생성
+    order = Order.objects.create(
+        table_usage=cart.table_usage,
+        cart=cart,
+        order_price=order_price,
+        original_price=subtotal,
+        total_discount=discount_total,
+        coupon_id=(applied_coupon.id if applied_coupon else None),  # 모델 help_text는 "Spring 관리"지만 우선 로깅용으로라도 박아두는 게 유용
+        order_status="PAID",
+    )
+
+    # OrderItem 생성 + 재고 차감까지 같이 처리
+    for it in cart_items:
+        if it.menu_id:
+            menu = locked_menus[it.menu_id]
+
+            OrderItem.objects.create(
+                order=order,
+                menu=menu,
+                setmenu=None,
+                parent=None,
+                quantity=it.quantity,
+                fixed_price=int(it.price_at_cart),
+                status="cooking",
+            )
+
+            menu.stock = F("stock") - it.quantity
+            menu.save(update_fields=["stock"])
+
+        else:
+            setmenu = it.setmenu
+            parent_item = OrderItem.objects.create(
+                order=order,
+                menu=None,
+                setmenu=setmenu,
+                parent=None,
+                quantity=it.quantity,
+                fixed_price=int(it.price_at_cart),
+                status="cooking",
+            )
+
+            comps = set_components.get(setmenu.id, [])
+            if not comps:
+                raise CartError("세트 구성 정보가 없습니다.", "SETMENU_INVALID", status_code=400)
+
+            for comp in comps:
+                child_menu = locked_menus[comp.menu_id]
+                child_qty = it.quantity * comp.quantity
+
+                OrderItem.objects.create(
+                    order=order,
+                    menu=child_menu,
+                    setmenu=None,
+                    parent=parent_item,
+                    quantity=child_qty,
+                    fixed_price=int(child_menu.price),
+                    status="cooking",
+                )
+
+                child_menu.stock = F("stock") - child_qty
+                child_menu.save(update_fields=["stock"])
+
+    # 5) Booth.total_revenues 반영
     booth = cart.table_usage.table.booth
-    amount = cart.cart_price
+    Booth.objects.filter(pk=booth.pk).update(total_revenues=F("total_revenues") + order_price)
 
-    payment = {
-        "depositor": booth.depositor,
-        "bank_name": booth.bank,
-        "account": booth.account,
-        "amount": amount,
-    }
-    return cart, payment
+    # 6) Cart 상태/라운드/아이템 정리 (재사용 정책)
+    cart.status = Cart.Status.ORDERED
+    cart.save(update_fields=["status"])
+
+    cart.items.all().delete()
+
+    cart.round += 1
+    cart.status = Cart.Status.ACTIVE
+    cart.pending_expires_at = None
+    cart.save(update_fields=["round", "status", "pending_expires_at"])
+
+    return cart

--- a/django/cart/views.py
+++ b/django/cart/views.py
@@ -87,7 +87,7 @@ class CartDetailAPIView(APIView):
                 status=410,
             )
 
-        cart, _ = Cart.objects.get_or_create(table_usage=table_usage)
+        cart = get_or_create_cart_by_table_usage(query_serializer.validated_data["table_usage_id"])
 
         if cart.is_pending_expired():
             cart.status = Cart.Status.ACTIVE

--- a/django/coupon/services.py
+++ b/django/coupon/services.py
@@ -11,8 +11,7 @@ from table.models import *
 from cart.models import *
 from cart.services import *
 
-from .models import Coupon, CouponCode, CartCouponApply
-
+from .models import *
 
 class CouponError(Exception):
     def __init__(self, message, error_code="COUPON_ERROR", detail=None, status_code=400):
@@ -49,9 +48,20 @@ def _calc_discount(subtotal: int, discount_type: str, discount_value: Decimal) -
 
 
 @transaction.atomic
-def create_coupon_and_codes(*, booth_id: int, name: str, description: str | None,
-                            discount_type: str, discount_value: Decimal, quantity: int) -> Coupon:
-    booth = get_object_or_404(Booth, id=booth_id)
+def create_coupon_and_codes(
+    *,
+    booth: Booth,
+    name: str,
+    description: str | None,
+    discount_type: str,
+    discount_value: Decimal,
+    quantity: int,
+) -> Coupon:
+    # 변경
+    # created 변수가 없던거 수정
+
+    if quantity < 1:
+        raise CouponError("quantity는 1 이상이어야 합니다.", "VALIDATION_ERROR", status_code=400)
 
     coupon = Coupon.objects.create(
         booth=booth,
@@ -62,6 +72,7 @@ def create_coupon_and_codes(*, booth_id: int, name: str, description: str | None
         quantity=quantity,
     )
 
+    created = 0
     while created < quantity:
         code = _gen_code(6)
         try:
@@ -99,8 +110,10 @@ def delete_coupon_if_unused(*, coupon_id: int) -> None:
 def apply_coupon_code(*, table_usage_id: int, coupon_code_str: str):
     table_usage = get_object_or_404(TableUsage, id=table_usage_id)
     _ensure_table_usage_alive(table_usage)
+
     cart = get_object_or_404(Cart.objects.select_for_update(), table_usage=table_usage)
     _ensure_cart_active(cart)
+
     code = get_object_or_404(CouponCode.objects.select_for_update(), code=coupon_code_str)
 
     booth_id = table_usage.table.booth_id
@@ -114,13 +127,11 @@ def apply_coupon_code(*, table_usage_id: int, coupon_code_str: str):
         raise CouponError("이미 쿠폰이 적용되어 있습니다.", "COUPON_ALREADY_APPLIED", status_code=409)
 
     subtotal = recalc_cart_price(cart)
-
     discount_amount = _calc_discount(subtotal, code.coupon.discount_type, code.coupon.discount_value)
     total = subtotal - discount_amount
 
-    code.used_at = timezone.now()
-    code.save(update_fields=["used_at"])
-
+    # 변경 이유
+    # apply는 “예약”이고, 실제 사용(used_at)은 결제 확정(주문 생성) 시점에 찍어야 함
     CartCouponApply.objects.create(cart=cart, round=cart.round, coupon_code=code)
 
     return {
@@ -148,13 +159,17 @@ def cancel_coupon_apply(*, table_usage_id: int):
     cart = get_object_or_404(Cart.objects.select_for_update(), table_usage=table_usage)
     _ensure_cart_active(cart)
 
-    applied = CartCouponApply.objects.select_for_update().filter(cart=cart, round=cart.round).select_related("coupon_code").first()
+    applied = (
+        CartCouponApply.objects.select_for_update()
+        .filter(cart=cart, round=cart.round)
+        .select_related("coupon_code")
+        .first()
+    )
     if not applied:
         raise CouponError("적용된 쿠폰이 없습니다.", "COUPON_NOT_APPLIED", status_code=400)
-    code = applied.coupon_code
-    code.used_at = None
-    code.save(update_fields=["used_at"])
 
+    # 변경
+    # apply/cancel은 “예약” 상태만 변경. used_at은 결제 확정 단계에서만 변경해야 함
     applied.delete()
 
     subtotal = recalc_cart_price(cart)


### PR DESCRIPTION
## 🔍 What is the PR?

- 결제 확정 시점 처리 로직 finalize_payment_and_rotate_cart() 구현
- 쿠폰 로직 구조 개선
- TTL 복구 시점 수정 


## 📍 PR Point

- 결제 확정 시점 단일 트랜잭션 처리
- 동시성 대응: select_for_update()로 재고 row 잠금 처리
- Cart 재사용 구조(round 기반)에 맞춘 정리 로직 구현

## 📢 Notices

- 재고 차감은 결제 확정 시점에만 발생하도록 통일
- coupon/services.py에서 apply/cancel 시 used_at을 찍지 않도록 구조 변경 전제 

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues
- #100 