### PR TITLE
🐛 [Fix] - 장바구니 관련 버그 수정

### DIFF
--- a/django/cart/services.py
+++ b/django/cart/services.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 from django.db import transaction
-from django.db.models import F, Sum, Case, When, IntegerField
+from django.db.models import F, Sum, Case, When, IntegerField, OuterRef, Subquery
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 
@@ -35,7 +35,6 @@ def add_to_cart(*, table_usage_id: int, type: str, quantity: int, menu_id: int =
             menu=menu,
             setmenu=None,
             defaults={
-                "type": "menu",
                 "quantity": quantity,
                 "price_at_cart": menu.price,
             },
@@ -60,7 +59,6 @@ def add_to_cart(*, table_usage_id: int, type: str, quantity: int, menu_id: int =
             menu=None,
             setmenu=setmenu,
             defaults={
-                "type": "setmenu",
                 "quantity": quantity,
                 "price_at_cart": setmenu.price,
             },
@@ -175,11 +173,13 @@ def enter_payment_info(*, table_usage_id: int):
     cart.pending_expires_at = timezone.now() + timedelta(minutes=PENDING_TTL_MINUTES)
     cart.save(update_fields=["status", "pending_expires_at"])
 
+    booth = cart.table_usage.table.booth
+
     payment = {
-        "subtotal": subtotal,
-        "discount_total": discount_total,
-        "total": total,
-        "expires_at": cart.pending_expires_at,
+        "depositor": booth.depositor,
+        "bank_name": booth.bank,
+        "account": booth.account,
+        "amount": total,
     }
 
     return cart, payment
@@ -207,11 +207,18 @@ def _restore_if_pending_expired(cart: Cart):
 
 
 def _sync_item_prices_to_latest(cart: Cart) -> None:
+    menu_price_subquery = Subquery(
+        Menu.objects.filter(pk=OuterRef("menu_id")).values("price")[:1]
+    )
+    setmenu_price_subquery = Subquery(
+        SetMenu.objects.filter(pk=OuterRef("setmenu_id")).values("price")[:1]
+    )
+
     qs = CartItem.objects.select_for_update().filter(cart=cart)
     qs.update(
         price_at_cart=Case(
-            When(menu__isnull=False, then=F("menu__price")),
-            When(setmenu__isnull=False, then=F("setmenu__price")),
+            When(menu__isnull=False, then=menu_price_subquery),
+            When(setmenu__isnull=False, then=setmenu_price_subquery),
             default=F("price_at_cart"),
             output_field=IntegerField(),
         )

--- a/django/cart/views.py
+++ b/django/cart/views.py
@@ -98,11 +98,6 @@ class CartDetailAPIView(APIView):
 
         cart = get_or_create_cart_by_table_usage(query_serializer.validated_data["table_usage_id"])
 
-        if cart.is_pending_expired():
-            cart.status = Cart.Status.ACTIVE
-            cart.pending_expires_at = None
-            cart.save(update_fields=["status", "pending_expires_at"])
-
         recalc_cart_price(cart)
 
         items = []


### PR DESCRIPTION
## 🔍 What is the PR?

- _sync_item_prices_to_latest에서 F("menu__price") JOIN 참조로 인한 500 에러 수정
- enter_payment_info에서 Booth 계좌 정보 누락 수정
- CartDetailAPIView에서 중복 PENDING 복구 로직 제거


## 📍 PR Point

- F("menu__price") → Subquery + OuterRef 방식으로 교체해서 FieldError: Joined field references are not permitted 해결
- payment 응답에 depositor, bank_name, account, amount로 수
- CartDetailAPIView의 중복 _restore_if_pending_expired 로직 제거로 PENDING 상태에서도 장바구니 담기가 되던 버그 수정

## 📢 Notices

- PENDING 만료(3분) 복구는 get_or_create_cart_by_table_usage 내부의 _restore_if_pending_expired 한 곳에서만 처리됨

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 - #129