### PR TITLE
🐛 [Fix] - coupon 엑셀 다운로드 API 수정 및 로직 변경

### DIFF
--- a/django/coupon/serializers.py
+++ b/django/coupon/serializers.py
@@ -5,7 +5,6 @@ from .models import *
 
 
 class CouponCreateSerializer(serializers.Serializer):
-    booth_id = serializers.IntegerField()
     name = serializers.CharField(max_length=50, allow_blank=False)
     description = serializers.CharField(max_length=255, required=False, allow_null=True, allow_blank=True)
     discount_type = serializers.ChoiceField(choices=["RATE", "AMOUNT"])

--- a/django/coupon/services.py
+++ b/django/coupon/services.py
@@ -5,6 +5,9 @@ from django.db import transaction
 from django.db.models import Count, Q
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
+from io import BytesIO
+from openpyxl import Workbook
+from openpyxl.utils import get_column_letter
 
 from booth.models import *
 from table.models import *
@@ -177,3 +180,60 @@ def cancel_coupon_apply(*, table_usage_id: int):
         "summary": {"subtotal": subtotal, "discount_total": 0, "total": subtotal},
         "round": cart.round,
     }
+    
+def build_coupon_excel_for_booth(*, booth: Booth) -> bytes:
+    coupons = (
+        Coupon.objects.filter(booth=booth)
+        .prefetch_related("codes")
+        .order_by("-created_at", "id")
+    )
+
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "쿠폰 목록"
+
+    ws.append([
+        "쿠폰 이름",
+        "쿠폰 내용",
+        "할인 타입",
+        "할인 값",
+        "쿠폰 재고",
+        "코드",
+        "사용 여부",
+    ])
+
+    for coupon in coupons:
+        codes = coupon.codes.all().order_by("created_at")
+
+        # 코드가 없는 쿠폰도 한 줄은 보이게 바꿈
+        if not codes.exists():
+            ws.append([
+                coupon.name,
+                coupon.description or "",
+                coupon.get_discount_type_display(),
+                float(coupon.discount_value),
+                coupon.quantity,
+                "",
+                "미사용",
+            ])
+            continue
+
+        for code in codes:
+            ws.append([
+                coupon.name,
+                coupon.description or "",
+                coupon.get_discount_type_display(),
+                float(coupon.discount_value),
+                coupon.quantity,
+                code.code,
+                "사용" if code.used_at else "미사용",
+            ])
+
+    widths = [20, 30, 15, 12, 12, 18, 12]
+    for idx, width in enumerate(widths, start=1):
+        ws.column_dimensions[get_column_letter(idx)].width = width
+
+    stream = BytesIO()
+    wb.save(stream)
+    stream.seek(0)
+    return stream.getvalue()

--- a/django/coupon/urls.py
+++ b/django/coupon/urls.py
@@ -4,6 +4,6 @@ from .views import *
 urlpatterns = [
     path("", CouponListCreateAPIView.as_view(), name="coupon-list-create"),  # GET/POST
     path("<int:coupon_id>/", CouponDeleteAPIView.as_view(), name="coupon-delete"),
-    path("<int:coupon_id>/download/", CouponDownloadAPIView.as_view(), name="coupon-download"),
+    path("download/", CouponDownloadAPIView.as_view()),
     path("apply-coupon/", CouponApplyAPIView.as_view(), name="coupon-apply-cancel"),  # POST/DELETE
 ]

--- a/django/coupon/views.py
+++ b/django/coupon/views.py
@@ -132,46 +132,31 @@ class CouponDeleteAPIView(APIView):
 class CouponDownloadAPIView(APIView):
     permission_classes = [IsAuthenticated]
 
-    def get(self, request, coupon_id: int):
+    def get(self, request):
         try:
             booth = get_admin_booth(request)
         except CouponError as e:
             return error_response(e)
-        coupon = get_object_or_404(Coupon, id=coupon_id, booth=booth)
-        codes = CouponCode.objects.filter(coupon=coupon).order_by("created_at")
 
-        from openpyxl import Workbook
-        from openpyxl.utils import get_column_letter
-        from io import BytesIO
         from django.utils import timezone
 
-        wb = Workbook()
-        ws = wb.active
-        ws.title = "coupon_codes"
-
-        ws.append(["coupon_id", "coupon_name", "code", "used", "used_at", "created_at"])
-        for code in codes:
-            ws.append(
-                [
-                    coupon.id,
-                    coupon.name,
-                    code.code,
-                    bool(code.used_at),
-                    code.used_at.isoformat() if code.used_at else None,
-                    code.created_at.isoformat() if code.created_at else None,
-                ]
+        try:
+            file_bytes = build_coupon_excel_for_booth(booth=booth)
+        except Exception as e:
+            return Response(
+                {
+                    "message": "쿠폰 엑셀 다운로드 중 오류가 발생했습니다.",
+                    "data": {
+                        "error_code": "COUPON_DOWNLOAD_FAILED",
+                        "detail": str(e),
+                    },
+                },
+                status=500,
             )
 
-        for col in range(1, 7):
-            ws.column_dimensions[get_column_letter(col)].width = 22
-
-        stream = BytesIO()
-        wb.save(stream)
-        stream.seek(0)
-
-        filename = f"booth_{coupon.booth_id}_coupon_{coupon.id}_codes_{timezone.now().strftime('%Y%m%d')}.xlsx"
+        filename = f"booth_{booth.pk}_coupon_codes_{timezone.now().strftime('%Y%m%d')}.xlsx"
         resp = HttpResponse(
-            stream.getvalue(),
+            file_bytes,
             content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         )
         resp["Content-Disposition"] = f'attachment; filename="{filename}"'


### PR DESCRIPTION
## 🔍 What is the PR?

- 기존 개별 쿠폰 다운로드 API 제거 (/coupon/<coupon_id>/download/)
- 부스 전체 쿠폰 다운로드 API 추가 (/coupon/download/)
- 엑셀 생성 로직을 service 레이어로 분리 (build_coupon_excel_for_booth)
- 엑셀 컬럼 구성 (쿠폰 이름, 내용, 할인 타입, 할인 값, 재고, 코드, 사용 여부)
- 사용 여부를 used_at 기준으로 처리

## 📍 PR Point

- 기존 “단일 쿠폰 다운로드” 구조를 “부스 전체 다운로드”로 변경
- service 레이어로 엑셀 생성 로직을 분리하여 코드 가독성과 재사용성 향상

## 📢 Notices

- 응답은 JSON이 아닌 파일(binary) 형태이므로 Postman 사용 시 Send and Download 방식으로 확인 필요

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 - #131 