### PR TITLE
🐛 [Fix] #106 - 테이블리셋 401에러 수정 

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,6 +2,5 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/../../D-Order-v3_backend" vcs="Git" />
   </component>
 </project>

--- a/APISPEC.md
+++ b/APISPEC.md
@@ -97,6 +97,7 @@ Content-Type: application/json
 
 - **설명**: 오류 발생 시 서버로부터 받는 에러 메시지 및 상세 정보및 응답데이터 JSON 예시
 - **기입 내용**:
+
   ```json
 
   ```

--- a/spring/src/main/java/com/example/spring/controller/table/TableController.java
+++ b/spring/src/main/java/com/example/spring/controller/table/TableController.java
@@ -1,7 +1,9 @@
 package com.example.spring.controller.table;
 
+import com.example.spring.config.CookieUtil;
 import com.example.spring.dto.table.request.TableResetRequest;
 import com.example.spring.service.table.TableService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +27,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class TableController {
 
     private final TableService tableService;
+    private final CookieUtil cookieUtil;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     /**
@@ -32,9 +35,11 @@ public class TableController {
      * POST /api/v3/spring/table/reset
      */
     @PostMapping("/reset")
-    public ResponseEntity<Map<String, Object>> resetTables(@RequestBody TableResetRequest request, HttpServletResponse response) {
+    public ResponseEntity<Map<String, Object>> resetTables(@RequestBody TableResetRequest request, HttpServletRequest httpRequest, HttpServletResponse response) {
+        String accessToken = cookieUtil.getAccessTokenFromCookies(httpRequest.getCookies());
+        String refreshToken = cookieUtil.getRefreshTokenFromCookies(httpRequest.getCookies());
         try {
-            Map<String, Object> result = tableService.resetTables(request.getTable_nums(), response);
+            Map<String, Object> result = tableService.resetTables(request.getTable_nums(), accessToken, refreshToken, response);
             return ResponseEntity.ok(result);
         } catch (TableService.DjangoApiException e) {
             return handleDjangoError(e);

--- a/spring/src/main/java/com/example/spring/service/table/TableService.java
+++ b/spring/src/main/java/com/example/spring/service/table/TableService.java
@@ -48,7 +48,7 @@ public class TableService {
      * @param response HttpServletResponse (쿠키 설정용)
      * @return Django 응답 데이터
      */
-    public Map<String, Object> resetTables(List<Integer> tableNums, HttpServletResponse response) {
+    public Map<String, Object> resetTables(List<Integer> tableNums, String accessToken, String refreshToken, HttpServletResponse response) {
         String url = djangoApiBaseUrl + "/api/v3/django/booth/tables/reset/";
         Map<String, String> csrfData = DjangoApiUtil.getCsrfToken(restTemplate, djangoApiBaseUrl);
         Map<String, Object> requestBody = new HashMap<>();
@@ -64,7 +64,13 @@ public class TableService {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         if (csrfData.get("csrfToken") != null) headers.set("X-CSRFToken", csrfData.get("csrfToken"));
-        if (csrfData.get("csrfCookie") != null) headers.set(HttpHeaders.COOKIE, csrfData.get("csrfCookie"));
+
+        // 프론트엔드 요청 쿠키에서 추출한 JWT 토큰을 Django로 전달
+        StringBuilder cookieBuilder = new StringBuilder();
+        if (csrfData.get("csrfCookie") != null) cookieBuilder.append(csrfData.get("csrfCookie"));
+        if (accessToken != null) cookieBuilder.append("; access_token=").append(accessToken);
+        if (refreshToken != null) cookieBuilder.append("; refresh_token=").append(refreshToken);
+        if (cookieBuilder.length() > 0) headers.set(HttpHeaders.COOKIE, cookieBuilder.toString());
 
         try {
             ResponseEntity<Map<String, Object>> djangoResponse = restTemplate.exchange(url, HttpMethod.POST, new HttpEntity<>(jsonBody, headers), (Class<Map<String, Object>>) (Class<?>) Map.class);


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->
테이블리셋 401오류 수정했습니다. 

TableService.resetTables()에서 Django로 보내는 요청에 JWT 토큰을 포함시키지 않아서 생기는 문제였어서 수정했습니다..! 환경변수에서 불러오게했는데 환경변수가 아니고 프론트엔드에서 추출한다음 장고로 전달하는 방식으로 수정했습니다. 


## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #106 
<!-- - ex) #3 -->