### PR TITLE
🐛 [Fix] - 테이블 병합 시 PAID 주문 있는 경우 ProtectedError 500 수정

### DIFF
--- a/django/table/services.py
+++ b/django/table/services.py
@@ -423,6 +423,11 @@ class TableService:
                     rep_cart.round = round_offset
                     rep_cart.save(update_fields=['round'])
 
+            # Order.cart를 rep_cart로 업데이트 (PROTECT FK로 인한 삭제 실패 방지)
+            other_cart_ids = [c.id for c in other_carts]
+            if rep_cart and other_cart_ids:
+                Order.objects.filter(cart_id__in=other_cart_ids).update(cart=rep_cart)
+
             # 나머지 other_usage_ids의 cart 삭제 (CartItem CASCADE, CartCouponApply는 이미 이전됨)
             Cart.objects.filter(table_usage_id__in=other_usage_ids).delete()
 

--- a/django/table/tests.py
+++ b/django/table/tests.py
@@ -1164,3 +1164,25 @@ class MergeActiveUsagesTestCase(TestCase):
         self._call([self.t1, self.t2, self.t3])
         self.assertEqual(TableCoupon.objects.count(), 1)
         self.assertTrue(TableCoupon.objects.filter(table_usage=self._rep_usage(self.t1)).exists())
+
+    # ─── 회귀 테스트 ──────────────────────────────────────────────────────
+
+    def test_paid_order_있는_테이블_병합시_ProtectedError_없음(self):
+        """PAID 주문이 있는 테이블 병합 시 ProtectedError 없이 성공해야 함"""
+        from cart.models import Cart
+        self._usage(self.t1, minutes_ago=30)
+        usage2 = self._usage(self.t2, minutes_ago=20)
+        other_cart = Cart.objects.create(table_usage=usage2, cart_price=5000)
+        order = Order.objects.create(
+            table_usage=usage2,
+            cart=other_cart,
+            order_price=5000,
+            original_price=5000,
+            order_status='PAID',
+        )
+
+        self._call([self.t1, self.t2])
+
+        order.refresh_from_db()
+        rep_cart = Cart.objects.get(table_usage=self._rep_usage(self.t1))
+        self.assertEqual(order.cart, rep_cart)


### PR DESCRIPTION
## 🔍 What is the PR?

- 테이블 병합 시 PAID 상태 주문이 있는 경우 `ProtectedError`로 500 에러 발생하는 버그 수정
- `_merge_active_usages`에서 Cart 삭제 전 `Order.cart`를 `rep_cart`로 업데이트하도록 수정
- 회귀 테스트 추가

## 📍 PR Point

`Order.cart`는 `on_delete=PROTECT`로 설정되어 있어, 참조 중인 Cart를 삭제하면 `ProtectedError`가 발생함.

기존 코드는 `Order.table_usage`만 대표 usage로 이전하고 `Order.cart`는 그대로 두었기 때문에, 이후 old Cart 삭제 시 충돌 발생.

```python
# 수정 전 (services.py:426)
Cart.objects.filter(table_usage_id__in=other_usage_ids).delete()  # ProtectedError

# 수정 후
other_cart_ids = [c.id for c in other_carts]
if rep_cart and other_cart_ids:
    Order.objects.filter(cart_id__in=other_cart_ids).update(cart=rep_cart)
Cart.objects.filter(table_usage_id__in=other_usage_ids).delete()
```

## 📢 Notices

없음

## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

- #146