### PR TITLE
🐛 [Fix] #106 - JwtUtil claim 이름 오타 수정

### DIFF
--- a/spring/src/main/java/com/example/spring/config/JwtUtil.java
+++ b/spring/src/main/java/com/example/spring/config/JwtUtil.java
@@ -82,7 +82,7 @@ public class JwtUtil {
      */
     public Long getBoothIdFromToken(String token) {
         Claims claims = parseClaims(token);
-        Object boothIdObj = claims.get("user_id"); // 실제 claim 이름은 user_id
+        Object boothIdObj = claims.get("booth_id");
         if (boothIdObj instanceof String) {
             return Long.valueOf((String) boothIdObj);
         } else if (boothIdObj instanceof Number) {

--- a/spring/src/main/java/com/example/spring/controller/table/TableController.java
+++ b/spring/src/main/java/com/example/spring/controller/table/TableController.java
@@ -7,7 +7,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-// ...existing code...
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->

- `JwtUtil.getBoothIdFromToken()`에서 claim 이름 오타 수정 (`user_id` → `booth_id`)

## 📍 PR Point

<!-- 나 이 부분 찢었다~! -->
- `generateAccessToken()`에서 `"booth_id"`로 저장하는데 `getBoothIdFromToken()`에서 `"user_id"`로 읽고 있어 항상 null 반환하던 버그 수정

## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
- #106
<!-- - ex) #3 -->