### PR TITLE
🐛 [Fix] 프로덕션 배포 안정화 (ALLOWED_HOSTS, nginx domain, Spring profile)

### DIFF
--- a/django/project/settings.py
+++ b/django/project/settings.py
@@ -60,7 +60,12 @@ def get_allowed_hosts():
     else:  # IS_PRODUCTION
         hosts_str = env('ALLOWED_HOSTS_PRODUCTION')
 
-    return [host.strip() for host in hosts_str.split(',')]
+    hosts = [host.strip() for host in hosts_str.split(',')]
+    # Docker 내부 healthcheck는 localhost로 요청하므로 항상 포함
+    for h in ['localhost', '127.0.0.1']:
+        if h not in hosts:
+            hosts.append(h)
+    return hosts
 
 ALLOWED_HOSTS = get_allowed_hosts() 
 

--- a/nginx/prod.conf
+++ b/nginx/prod.conf
@@ -50,7 +50,7 @@ http {
     server {
         listen 80;
         listen [::]:80;
-        server_name prod.dorder-api.shop;
+        server_name ${DOMAIN};
 
         location /.well-known/acme-challenge/ {
             root /var/www/certbot;
@@ -65,7 +65,7 @@ http {
     server {
         listen 443 ssl http2;
         listen [::]:443 ssl http2;
-        server_name prod.dorder-api.shop;
+        server_name ${DOMAIN};
 
         ssl_certificate /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
         ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;

--- a/spring/Dockerfile
+++ b/spring/Dockerfile
@@ -69,5 +69,4 @@ ENTRYPOINT ["java", \
     "-Djava.security.egd=file:/dev/./urandom", \
     "-jar", "app.jar"]
 
-# 기본 프로필은 docker-compose에서 환경변수로 오버라이드
-CMD ["--spring.profiles.active=dev"]
+# 프로필은 SPRING_PROFILES_ACTIVE 환경변수로 설정 (docker-compose에서 주입)

--- a/spring/src/main/resources/application.yml
+++ b/spring/src/main/resources/application.yml
@@ -4,8 +4,6 @@
 spring:
   application:
     name: spring
-  profiles:
-    active: local
 
   jpa:
     hibernate:


### PR DESCRIPTION
## 🔍 What is the PR?

- Django `ALLOWED_HOSTS`에 `localhost`, `127.0.0.1` 추가 — Docker 내부 healthcheck가 `localhost:8000`으로 요청하여 `DisallowedHost` 에러 발생하던 문제 수정
- nginx `prod.conf` `server_name` 하드코딩(`prod.dorder-api.shop`) → `${DOMAIN}` 치환으로 변경 — `.env`의 `DOMAIN` 변수와 불일치로 인증서 경로 미스매치 수정
- Spring `Dockerfile` CMD의 `--spring.profiles.active=dev` 제거 — 커맨드라인 인자가 `SPRING_PROFILES_ACTIVE=prod` 환경변수를 덮어써서 항상 dev 프로파일로 기동되던 버그 수정
- Spring `application.yml` 공통 섹션의 `spring.profiles.active: local` 하드코딩 제거

## 📍 PR Point

- Spring Boot에서 커맨드라인 인자 우선순위 > 환경변수이므로, Dockerfile CMD에 프로파일이 지정되어 있으면 docker-compose의 `SPRING_PROFILES_ACTIVE` env가 무시됨
- nginx `envsubst`가 `${DOMAIN}`만 치환하므로 `server_name`도 동일하게 변수화해야 인증서 경로와 일치

## 📢 Notices

없음

## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 - #