### PR TITLE
🐛 [Fix] deploy ps 명령에 --profile blue 누락 수정

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -242,7 +242,7 @@ jobs:
               docker image prune -f
             fi
 
-            docker compose -f docker-compose.prod.yml ps
+            docker compose -f docker-compose.prod.yml --profile blue ps
 
       # Django만 Blue-Green 배포 (PROD-DJANGO 라벨)
       - name: Deploy DJANGO only (Blue-Green)


### PR DESCRIPTION
## 🔍 What is the PR?

- `docker compose ps` 명령에 `--profile blue` 누락으로 `service "nginx" depends on undefined service "django-blue"` 에러 발생 → 배포 스크립트 exit 1로 종료되던 문제 수정

## 📍 PR Point

- `docker-compose.prod.yml`에서 `nginx`가 `django-blue`(profile: blue)에 `depends_on`하고 있어서, `--profile blue` 없이 `docker compose ps` 실행 시 해당 서비스를 찾지 못함

## 📢 Notices

없음

## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 - #