### PR TITLE
🐛 [Fix] Spring 컨테이너 Dockerfile CMD가 SPRING_PROFILES_ACTIVE 환경변수 무시하는 버그 우회

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -159,6 +159,7 @@ services:
     image: ${DOCKER_USERNAME:-local}/d-order-spring:prod
     container_name: d-order-spring-blue-prod
     profiles: ['blue']
+    command: []
     environment:
       SPRING_PROFILES_ACTIVE: prod
       POSTGRES_DB: ${POSTGRES_DB}
@@ -197,6 +198,7 @@ services:
     image: ${DOCKER_USERNAME:-local}/d-order-spring:prod
     container_name: d-order-spring-green-prod
     profiles: ['green']
+    command: []
     environment:
       SPRING_PROFILES_ACTIVE: prod
       POSTGRES_DB: ${POSTGRES_DB}


### PR DESCRIPTION
## 🔍 What is the PR?

- Spring Dockerfile의 `CMD ["--spring.profiles.active=dev"]`가 Spring Boot에서 커맨드라인 인자로 처리되어 `SPRING_PROFILES_ACTIVE=prod` 환경변수보다 높은 우선순위로 적용됨
- 결과적으로 docker-compose에서 `SPRING_PROFILES_ACTIVE: prod`를 설정해도 항상 dev 프로파일로 기동되어 `UnknownHostException: postgres` 에러 발생
- `docker-compose.prod.yml`의 spring-blue, spring-green에 `command: []` 추가하여 Dockerfile CMD를 무효화

## 📍 PR Point

- Dockerfile CMD는 별도 PR(#159)에서 제거했으나 이미지 빌드 캐시 문제로 Docker Hub에 반영되지 않음
- compose의 `command: []`로 즉시 우회 적용 가능

## 📢 Notices

없음

## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 - #