### PR TITLE
fix - Spring prod 프로파일 및 ddl-auto 설정 수정

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -159,7 +159,7 @@ services:
     image: ${DOCKER_USERNAME:-local}/d-order-spring:prod
     container_name: d-order-spring-blue-prod
     profiles: ['blue']
-    command: []
+    command: ["--spring.profiles.active=prod"]
     environment:
       SPRING_PROFILES_ACTIVE: prod
       POSTGRES_DB: ${POSTGRES_DB}
@@ -198,7 +198,7 @@ services:
     image: ${DOCKER_USERNAME:-local}/d-order-spring:prod
     container_name: d-order-spring-green-prod
     profiles: ['green']
-    command: []
+    command: ["--spring.profiles.active=prod"]
     environment:
       SPRING_PROFILES_ACTIVE: prod
       POSTGRES_DB: ${POSTGRES_DB}


### PR DESCRIPTION
## Summary
- Spring `command: []` → `command: ["--spring.profiles.active=prod"]` (빈 리스트 무시 버그 수정)
- Spring prod `ddl-auto: validate` → `update` (RDS 도입으로 Django 마이그레이션이 먼저 실행되어 스키마 불일치 발생)

## Root Cause
- dev: `ddl-auto: update`로 Spring이 직접 테이블 생성 → 정상
- prod: `ddl-auto: validate`로 Django 마이그레이션 스키마와 비교 → `missing column [key] in table [orderitem]` 에러

## Test plan
- [ ] PR 머지 후 GitHub Actions 배포 실행
- [ ] `docker logs d-order-spring-blue-prod | grep "profile is active"` → `prod` 확인
- [ ] `curl -sf https://prod.dorder-api.shop/health/spring` → 200 확인