### PR TITLE
fix - Safari WebSocket 쿠키 인증 (커스텀 도메인 방식)

### DIFF
--- a/django/project/settings.py
+++ b/django/project/settings.py
@@ -234,6 +234,7 @@ SIMPLE_JWT = {
     'AUTH_COOKIE_HTTP_ONLY': True,
     # 'AUTH_COOKIE_SAMESITE': 'None' if not IS_LOCAL else 'Lax',  # cross-origin 쿠키 전송 허용
     'AUTH_COOKIE_SAMESITE': 'Lax',  # cross-origin 쿠키 전송 허용
+    'AUTH_COOKIE_DOMAIN': None if IS_LOCAL else '.dorder-api.shop',
 }
 
 # Logging 설정
@@ -426,10 +427,12 @@ CSRF_COOKIE_NAME = 'csrftoken'              # 쿠키 이름
 CSRF_COOKIE_SECURE = env.bool('CSRF_COOKIE_SECURE', default=not IS_LOCAL)
 CSRF_COOKIE_HTTPONLY = False                # JavaScript에서 접근 가능 (React에서 필요)
 CSRF_COOKIE_SAMESITE = 'Lax'
+CSRF_COOKIE_DOMAIN = None if IS_LOCAL else '.dorder-api.shop'
 
 SESSION_COOKIE_SECURE = env.bool('SESSION_COOKIE_SECURE', default=IS_PRODUCTION)
 SESSION_COOKIE_HTTPONLY = env.bool('SESSION_COOKIE_HTTPONLY', default=True)
 SESSION_COOKIE_SAMESITE = 'Lax'
+SESSION_COOKIE_DOMAIN = None if IS_LOCAL else '.dorder-api.shop'
 
 
 # CSRF 설정


### PR DESCRIPTION
## Summary
- `AUTH_COOKIE_DOMAIN`, `CSRF_COOKIE_DOMAIN`, `SESSION_COOKIE_DOMAIN`을 `.dorder-api.shop`으로 설정
- 프론트(`*.dorder-api.shop`)와 백엔드(`prod.dorder-api.shop`)가 same-site가 되어 SameSite=Lax 쿠키가 WebSocket 핸드셰이크에도 전송됨
- 로컬 환경은 `None` 유지

## 관련 이슈
- Safari/iOS에서 쿠키가 저장되지 않는 문제 해결
- WebSocket 연결 시 JWT 인증 불가 문제 해결

## 추가 작업 필요
- 서버 `.env`: `CORS_ALLOWED_ORIGINS_FRONTEND` 업데이트
- DNS: `admin/customer/server.dorder-api.shop` CNAME 등록
- Netlify: 각 사이트에 커스텀 도메인 추가
- Spring: `SPRING_COOKIE_DOMAIN_SETUP.md` 참고하여 별도 적용

## Test plan
- [ ] Safari에서 `https://admin.dorder-api.shop` 로그인 → 쿠키 `Domain: .dorder-api.shop` 확인
- [ ] WebSocket 연결 403 없이 정상 동작 확인
- [ ] Chrome 기존 동작 유지 확인