### PR TITLE
fix - JWT 쿠키 domain 파라미터 누락 수정

### DIFF
--- a/django/authentication/utils.py
+++ b/django/authentication/utils.py
@@ -17,6 +17,7 @@ def set_jwt_cookies(response, access_token, refresh_token):
         response: 쿠키가 설정된 Response 객체
     """
     jwt_settings = settings.SIMPLE_JWT
+    domain = jwt_settings.get('AUTH_COOKIE_DOMAIN')
 
     # Access Token 쿠키 설정
     response.set_cookie(
@@ -26,6 +27,7 @@ def set_jwt_cookies(response, access_token, refresh_token):
         httponly=jwt_settings.get('AUTH_COOKIE_HTTP_ONLY'),
         samesite=jwt_settings.get('AUTH_COOKIE_SAMESITE'),
         secure=jwt_settings.get('AUTH_COOKIE_SECURE'),
+        domain=domain,
     )
 
     # Refresh Token 쿠키 설정
@@ -36,6 +38,7 @@ def set_jwt_cookies(response, access_token, refresh_token):
         httponly=jwt_settings.get('AUTH_COOKIE_HTTP_ONLY'),
         samesite=jwt_settings.get('AUTH_COOKIE_SAMESITE'),
         secure=jwt_settings.get('AUTH_COOKIE_SECURE'),
+        domain=domain,
     )
 
     return response
@@ -54,8 +57,9 @@ def delete_jwt_cookies(response):
     jwt_settings = settings.SIMPLE_JWT
 
     samesite = jwt_settings.get('AUTH_COOKIE_SAMESITE')
+    domain = jwt_settings.get('AUTH_COOKIE_DOMAIN')
 
-    response.delete_cookie(jwt_settings.get('AUTH_COOKIE'), samesite=samesite)
-    response.delete_cookie(jwt_settings.get('AUTH_COOKIE_REFRESH'), samesite=samesite)
+    response.delete_cookie(jwt_settings.get('AUTH_COOKIE'), samesite=samesite, domain=domain)
+    response.delete_cookie(jwt_settings.get('AUTH_COOKIE_REFRESH'), samesite=samesite, domain=domain)
 
     return response


### PR DESCRIPTION
## Summary
- `set_jwt_cookies()`에 `domain=AUTH_COOKIE_DOMAIN` 파라미터 누락으로 JWT 쿠키가 `admin.dorder-api.shop`에만 귀속되는 문제 수정
- `delete_jwt_cookies()`도 동일하게 domain 파라미터 추가
- 이로 인해 `wss://prod.dorder-api.shop` WebSocket 연결 시 쿠키가 전송되지 않았음

## 원인
PR#176에서 `settings.py`에 `AUTH_COOKIE_DOMAIN`을 추가했지만, `utils.py`의 `set_cookie()` 호출에 `domain=` 파라미터가 없어서 실제로 적용되지 않음

## Test plan
- [ ] 로그인 후 쿠키 Domain이 `.dorder-api.shop`인지 확인
- [ ] WebSocket 연결 시 쿠키 전송 확인 (`No token in cookie` 로그 사라짐)