### PR TITLE
🔧 [Chore] #106 - Spring Boot 프로덕션 쿠키 도메인 및 CORS 설정 추가

### DIFF
--- a/spring/src/main/java/com/example/spring/config/CookieUtil.java
+++ b/spring/src/main/java/com/example/spring/config/CookieUtil.java
@@ -29,6 +29,7 @@ public class CookieUtil {
                 .httpOnly(jwtProperties.getCookie().isHttpOnly())
                 .sameSite(jwtProperties.getCookie().getSameSite())
                 .secure(jwtProperties.getCookie().isSecure())
+                .domain(jwtProperties.getCookie().getDomain())
                 .path("/")
                 .build();
 
@@ -41,6 +42,7 @@ public class CookieUtil {
                 .httpOnly(jwtProperties.getCookie().isHttpOnly())
                 .sameSite(jwtProperties.getCookie().getSameSite())
                 .secure(jwtProperties.getCookie().isSecure())
+                .domain(jwtProperties.getCookie().getDomain())
                 .path("/")
                 .build();
 
@@ -61,6 +63,7 @@ public class CookieUtil {
                 .httpOnly(jwtProperties.getCookie().isHttpOnly())
                 .sameSite(jwtProperties.getCookie().getSameSite())
                 .secure(jwtProperties.getCookie().isSecure())
+                .domain(jwtProperties.getCookie().getDomain())
                 .path("/")
                 .build();
 
@@ -73,6 +76,7 @@ public class CookieUtil {
                 .httpOnly(jwtProperties.getCookie().isHttpOnly())
                 .sameSite(jwtProperties.getCookie().getSameSite())
                 .secure(jwtProperties.getCookie().isSecure())
+                .domain(jwtProperties.getCookie().getDomain())
                 .path("/")
                 .build();
 

--- a/spring/src/main/java/com/example/spring/config/JwtProperties.java
+++ b/spring/src/main/java/com/example/spring/config/JwtProperties.java
@@ -27,5 +27,6 @@ public class JwtProperties {
         private boolean httpOnly = true;
         private String sameSite = "Lax";
         private boolean secure = false;
+        private String domain = ""; // 로컬: 빈 문자열 = Domain 속성 생략, prod: .dorder-api.shop
     }
 }

--- a/spring/src/main/java/com/example/spring/config/SecurityConfig.java
+++ b/spring/src/main/java/com/example/spring/config/SecurityConfig.java
@@ -86,8 +86,11 @@ public class SecurityConfig {
                 "https://127.0.0.1:5173",
                 "http://127.0.0.1:5174",
                 "https://127.0.0.1:5174",
-                "https://dev.dorder-api.shop",  // 필수 추가
-                "http://dev.dorder-api.shop"    // 필수 추가
+                "https://dev.dorder-api.shop",
+                "http://dev.dorder-api.shop",
+                "https://admin.dorder-api.shop",
+                "https://customer.dorder-api.shop",
+                "https://server.dorder-api.shop"
         ));
 
         // 허용할 HTTP 메서드

--- a/spring/src/main/resources/application.yml
+++ b/spring/src/main/resources/application.yml
@@ -138,6 +138,12 @@ spring:
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD:}
 
+jwt:
+  cookie:
+    secure: true
+    same-site: None      # Django와 동일 (Safari/iOS WebSocket 쿠키 누락 방지)
+    domain: .dorder-api.shop  # 모든 서브도메인 쿠키 공유
+
 # 서버 설정
 server:
   port: 8080


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->

- `application.yml` prod 프로파일에 JWT 쿠키 보안 설정 추가
- `JwtProperties.java` Cookie에 domain 필드 추가
- `CookieUtil.java` ResponseCookie 빌더에 domain 적용
- `SecurityConfig.java` 프로덕션 CORS 허용 도메인 추가

## 📍 PR Point

<!-- 나 이 부분 찢었다~! -->


- prod 환경에서 `Domain=.dorder-api.shop` 설정으로 모든 서브도메인 쿠키 공유
- `SameSite=None + Secure=true` 적용 (Django settings.py와 동일하게 맞춤)
- 로컬 환경은 기존 설정(`SameSite=Lax`, `Secure=false`, Domain 없음) 그대로 유지

## 📢 Notices

 <!-- 공용으로 사용하는(Extension) 부분에 대한 설명 -->

- `CookieUtil.java`는 공통 쿠키 유틸이라 로그인/로그아웃/토큰갱신 전부 영향받음
- 로컬은 `domain: ""`(기본값)이라 변경 없음, prod 배포 시에만 적용됨
## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #106
<!-- - ex) #3 -->