### PR TITLE
🐛 [Fix] dev 환경 JWT 쿠키 SameSite=None 복원 (로컬 프론트 cross-origin 로그인)

### DIFF
--- a/django/project/settings.py
+++ b/django/project/settings.py
@@ -232,8 +232,7 @@ SIMPLE_JWT = {
     'AUTH_COOKIE_REFRESH': 'refresh_token',
     'AUTH_COOKIE_SECURE': not IS_LOCAL,  # local 제외 HTTPS 환경에서 Secure
     'AUTH_COOKIE_HTTP_ONLY': True,
-    # 'AUTH_COOKIE_SAMESITE': 'None' if not IS_LOCAL else 'Lax',  # cross-origin 쿠키 전송 허용
-    'AUTH_COOKIE_SAMESITE': 'Lax',  # cross-origin 쿠키 전송 허용
+    'AUTH_COOKIE_SAMESITE': 'None' if IS_DEVELOPMENT else 'Lax',  # dev: cross-origin 쿠키 전송 허용
     'AUTH_COOKIE_DOMAIN': None if IS_LOCAL else '.dorder-api.shop',
 }
 


### PR DESCRIPTION
## 🔍 What is the PR?

- `AUTH_COOKIE_SAMESITE`를 dev 환경에서 `'None'`으로 복원
- 기존: `'Lax'` (전 환경 동일) → 수정: `'None' if IS_DEVELOPMENT else 'Lax'`

## 📍 PR Point

upstream dev 풀 이후 `SameSite=Lax`로 하드코딩되면서, 로컬 프론트(localhost)에서 dev 서버(dev.dorder-api.shop)로의 cross-site 요청 시 JWT 쿠키가 전송되지 않아 인증이 실패하는 문제가 발생함

- 로컬 ↔ dev 서버는 도메인이 달라 **cross-site 요청**
- `SameSite=Lax`는 JavaScript fetch/axios 요청에서 cross-site 쿠키 전송을 차단
- HttpOnly JWT 쿠키는 JS로 직접 읽을 수 없어 브라우저 자동 전송에 의존 → 인증 완전 불가
- dev 서버는 HTTPS이므로 `SameSite=None`은 `Secure=True`와 함께 안전하게 사용 가능

## 📢 Notices

| 환경 | SameSite | 이유 |
|------|----------|------|
| local | `Lax` | 로컬은 same-origin |
| development | `None` | 로컬 프론트 ↔ dev 서버 cross-origin 허용 |
| production | `Lax` | 프론트/백엔드 same-site |

## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 - #