### PR TITLE
🐛 [Fix] table WebSocket URL 패턴 $ 앵커 누락 수정

### DIFF
--- a/django/table/routing.py
+++ b/django/table/routing.py
@@ -2,6 +2,6 @@ from django.urls import re_path
 from .consumers import TableConsumer, TableDetailConsumer
 
 websocket_urlpatterns = [
-    re_path(r'ws/django/booth/tables/(?P<table_num>\d+)/', TableDetailConsumer.as_asgi()),
-    re_path(r'ws/django/booth/tables/', TableConsumer.as_asgi()),
+    re_path(r'ws/django/booth/tables/(?P<table_num>\d+)/$', TableDetailConsumer.as_asgi()),
+    re_path(r'ws/django/booth/tables/$', TableConsumer.as_asgi()),
 ]


### PR DESCRIPTION
## 🔍 What is the PR?

- `table/routing.py` WebSocket URL 패턴에 `$` 앵커 추가

## 📍 PR Point

`ws/django/booth/tables/` 패턴에 `$`가 없어 `ws/django/booth/tables/<table_num>/` 요청이 `TableDetailConsumer` 대신 `TableConsumer`로 잘못 라우팅될 수 있었음.

`order/routing.py`, `cart/routing.py`는 이미 `$` 사용 중이었으나 table만 누락된 상태.

```python
# 수정 전
re_path(r'ws/django/booth/tables/(?P<table_num>\d+)/', TableDetailConsumer.as_asgi()),
re_path(r'ws/django/booth/tables/', TableConsumer.as_asgi()),

# 수정 후
re_path(r'ws/django/booth/tables/(?P<table_num>\d+)/$', TableDetailConsumer.as_asgi()),
re_path(r'ws/django/booth/tables/$', TableConsumer.as_asgi()),
```

## 📢 Notices

없음

## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 - #182