### PR TITLE
🐛 [Fix] #106 - YAML SameSite None 파싱 오류 수정

### DIFF
--- a/spring/src/main/resources/application.yml
+++ b/spring/src/main/resources/application.yml
@@ -141,7 +141,7 @@ spring:
 jwt:
   cookie:
     secure: true
-    same-site: None      # Django와 동일 (Safari/iOS WebSocket 쿠키 누락 방지)
+    same-site: "None"    # Django와 동일 (Safari/iOS WebSocket 쿠키 누락 방지) - 따옴표 필수 (YAML에서 None은 null로 파싱됨)
     domain: .dorder-api.shop  # 모든 서브도메인 쿠키 공유
 
 # 서버 설정


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->

- `application.yml` prod 프로파일의 `same-site: None` → `same-site: "None"` 따옴표 처리


## 📍 PR Point

<!-- 나 이 부분 찢었다~! -->

- YAML 1.1에서 `None`은 `null`로 파싱되어 SameSite=Lax로 폴백되던 문제 수정
- 따옴표로 감싸 문자열 "None"으로 인식되도록 하여 Safari/iOS WebSocket 쿠키 누락 방지
## 📢 Notices

 <!-- 공용으로 사용하는(Extension) 부분에 대한 설명 -->

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #106 
<!-- - ex) #3 -->