### PR TITLE
✨ [Feat] #185 - 서버 호출을 구현한다

### DIFF
--- a/nginx/dev.conf
+++ b/nginx/dev.conf
@@ -174,6 +174,24 @@ http {
             proxy_send_timeout 86400;
         }
 
+        # Spring — 직원 호출(부스별 구독)
+        location /ws/server/staffcall {
+            proxy_pass http://spring_backend;
+            proxy_http_version 1.1;
+
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_read_timeout 86400;
+            proxy_connect_timeout 86400;
+            proxy_send_timeout 86400;
+        }
+
         # API 엔드포인트 - Django
         location /api/v3/django/ {
             proxy_pass http://django_backend;

--- a/nginx/prod.conf
+++ b/nginx/prod.conf
@@ -146,6 +146,24 @@ http {
             proxy_send_timeout 86400;
         }
 
+        # WebSocket - Spring (직원 호출)
+        location /ws/server/staffcall {
+            proxy_pass http://spring_backend;
+            proxy_http_version 1.1;
+
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_read_timeout 86400;
+            proxy_connect_timeout 86400;
+            proxy_send_timeout 86400;
+        }
+
         # API - Django (rate limiting 적용)
         location /api/v3/django/ {
             limit_req zone=api burst=20 nodelay;

--- a/spring/src/main/java/com/example/spring/config/JwtUtil.java
+++ b/spring/src/main/java/com/example/spring/config/JwtUtil.java
@@ -82,14 +82,27 @@ public class JwtUtil {
      */
     public Long getBoothIdFromToken(String token) {
         Claims claims = parseClaims(token);
+        // Django SimpleJWT 기본 클레임은 user_id — 이 프로젝트는 Booth.pk == User.pk 이므로 동일
         Object boothIdObj = claims.get("booth_id");
+        if (boothIdObj == null) {
+            boothIdObj = claims.get("user_id");
+        }
         if (boothIdObj instanceof String) {
             return Long.valueOf((String) boothIdObj);
         } else if (boothIdObj instanceof Number) {
             return ((Number) boothIdObj).longValue();
         } else {
-            throw new IllegalArgumentException("booth_id claim 타입 변환 실패: " + boothIdObj);
+            throw new IllegalArgumentException("booth_id/user_id claim 없음 또는 타입 변환 실패: " + boothIdObj);
         }
+    }
+
+    /**
+     * SimpleJWT 호환 username 클레임 (직원 호출 수락 시 accepted_by 등)
+     */
+    public String getUsernameFromToken(String token) {
+        Claims claims = parseClaims(token);
+        Object username = claims.get("username");
+        return username != null ? username.toString() : null;
     }
 
     

--- a/spring/src/main/java/com/example/spring/config/SecurityConfig.java
+++ b/spring/src/main/java/com/example/spring/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.spring.config;
 
+import com.example.spring.security.ServerApiJwtFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -8,6 +9,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -26,12 +28,15 @@ import java.util.List;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final ServerApiJwtFilter serverApiJwtFilter;
+
     /**
      * Spring Security 필터 체인 설정
      */
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                .addFilterBefore(serverApiJwtFilter, UsernamePasswordAuthenticationFilter.class)
                 // CSRF 비활성화 (JWT 쿠키 사용)
                 .csrf(AbstractHttpConfigurer::disable)
 

--- a/spring/src/main/java/com/example/spring/config/StaffCallHandshakeInterceptor.java
+++ b/spring/src/main/java/com/example/spring/config/StaffCallHandshakeInterceptor.java
@@ -1,0 +1,52 @@
+package com.example.spring.config;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.Map;
+
+/**
+ * 웹소켓 핸드셰이크 시 access_token 쿠키로 booth_id 확보
+ */
+@Component
+@RequiredArgsConstructor
+public class StaffCallHandshakeInterceptor implements HandshakeInterceptor {
+
+    public static final String ATTR_BOOTH_ID = "boothId";
+
+    private final CookieUtil cookieUtil;
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                                   WebSocketHandler wsHandler, Map<String, Object> attributes) {
+        if (!(request instanceof ServletServerHttpRequest servletRequest)) {
+            return false;
+        }
+        HttpServletRequest req = servletRequest.getServletRequest();
+        Cookie[] cookies = req.getCookies();
+        String token = cookieUtil.getAccessTokenFromCookies(cookies);
+        if (token == null || !jwtUtil.validateToken(token)) {
+            return false;
+        }
+        try {
+            Long boothId = jwtUtil.getBoothIdFromToken(token);
+            attributes.put(ATTR_BOOTH_ID, boothId);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                               WebSocketHandler wsHandler, Exception exception) {
+    }
+}

--- a/spring/src/main/java/com/example/spring/config/WebSocketConfig.java
+++ b/spring/src/main/java/com/example/spring/config/WebSocketConfig.java
@@ -1,12 +1,13 @@
 package com.example.spring.config;
 
 import com.example.spring.websocket.ServingWebSocketHandler;
+import com.example.spring.websocket.StaffCallWebSocketHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
-import org.springframework.web.socket.server.support.HttpSessionHandshakeInterceptor; // 1. 임포트 추가
+import org.springframework.web.socket.server.support.HttpSessionHandshakeInterceptor;
 
 @Configuration
 @EnableWebSocket
@@ -14,18 +15,27 @@ import org.springframework.web.socket.server.support.HttpSessionHandshakeInterce
 public class WebSocketConfig implements WebSocketConfigurer {
 
     private final ServingWebSocketHandler servingWebSocketHandler;
+    private final StaffCallWebSocketHandler staffCallWebSocketHandler;
+    private final StaffCallHandshakeInterceptor staffCallHandshakeInterceptor;
 
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
         registry.addHandler(servingWebSocketHandler, "/ws/serving")
-                // 1. 허용 도메인을 명확하게 지정 (패턴 사용)
                 .setAllowedOriginPatterns(
                         "http://localhost:5173",
                         "https://dev.dorder-api.shop",
                         "http://dev.dorder-api.shop",
-                        "https://*.dorder-api.shop" // 서브도메인 대비 안전장치
+                        "https://*.dorder-api.shop"
                 )
-                // 2. HTTP 세션 및 쿠키 정보를 웹소켓 핸드셰이크 시점에 유지해주는 인터셉터
                 .addInterceptors(new HttpSessionHandshakeInterceptor());
+
+        registry.addHandler(staffCallWebSocketHandler, "/ws/server/staffcall")
+                .setAllowedOriginPatterns(
+                        "http://localhost:5173",
+                        "https://dev.dorder-api.shop",
+                        "http://dev.dorder-api.shop",
+                        "https://*.dorder-api.shop"
+                )
+                .addInterceptors(staffCallHandshakeInterceptor, new HttpSessionHandshakeInterceptor());
     }
 }

--- a/spring/src/main/java/com/example/spring/controller/staffcall/StaffCallController.java
+++ b/spring/src/main/java/com/example/spring/controller/staffcall/StaffCallController.java
@@ -1,0 +1,83 @@
+package com.example.spring.controller.staffcall;
+
+import com.example.spring.dto.staffcall.request.StaffCallAcceptRequest;
+import com.example.spring.dto.staffcall.request.StaffCallEmitRequest;
+import com.example.spring.dto.staffcall.request.StaffCallListRequest;
+import com.example.spring.dto.staffcall.response.StaffCallAcceptResponse;
+import com.example.spring.security.ServerApiJwtFilter;
+import com.example.spring.service.staffcall.StaffCallConflictException;
+import com.example.spring.service.staffcall.StaffCallQueryService;
+import com.example.spring.service.staffcall.StaffCallService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/server")
+@RequiredArgsConstructor
+public class StaffCallController {
+
+    private final StaffCallQueryService staffCallQueryService;
+    private final StaffCallService staffCallService;
+
+    /**
+     * 직원 호출 발생 — 경로를 {@code /staffcall/{boothId}} 보다 먼저 등록 (request가 boothId로 오인되지 않도록)
+     */
+    @PostMapping("/staffcall/request")
+    public ResponseEntity<Map<String, Object>> emit(
+            @RequestBody StaffCallEmitRequest body,
+            HttpServletRequest request) {
+        Long boothId = (Long) request.getAttribute(ServerApiJwtFilter.ATTR_BOOTH_ID);
+        try {
+            return ResponseEntity.ok(staffCallService.emit(boothId, body));
+        } catch (StaffCallConflictException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("message", e.getMessage()));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("message", e.getMessage()));
+        }
+    }
+
+    /**
+     * POST /api/v3/spring/server/staffcall/{booth_id}
+     * JWT의 booth_id와 경로가 일치해야 함 (은호님: JWT만 써도 되지만 스펙 경로 유지)
+     */
+    @PostMapping("/staffcall/{boothId}")
+    public ResponseEntity<Map<String, Object>> list(
+            @PathVariable Long boothId,
+            @RequestBody(required = false) StaffCallListRequest body,
+            HttpServletRequest request) {
+        Long jwtBooth = (Long) request.getAttribute(ServerApiJwtFilter.ATTR_BOOTH_ID);
+        if (jwtBooth == null || !jwtBooth.equals(boothId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(Map.of("message", "부스 정보가 일치하지 않습니다."));
+        }
+        StaffCallListRequest req = body != null ? body : new StaffCallListRequest();
+        return ResponseEntity.ok(staffCallQueryService.listForBooth(boothId, req.getLimit(), req.getOffset()));
+    }
+
+    /**
+     * POST /api/v3/spring/server/accept
+     */
+    @PostMapping("/accept")
+    public ResponseEntity<Map<String, Object>> accept(
+            @RequestBody StaffCallAcceptRequest body,
+            HttpServletRequest request) {
+        Long boothId = (Long) request.getAttribute(ServerApiJwtFilter.ATTR_BOOTH_ID);
+        String accessToken = (String) request.getAttribute("ACCESS_TOKEN");
+        try {
+            StaffCallAcceptResponse data = staffCallService.accept(boothId, accessToken, body);
+            return ResponseEntity.ok(Map.of(
+                    "message", "호출을 수락했습니다.",
+                    "data", data
+            ));
+        } catch (StaffCallConflictException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("message", e.getMessage()));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("message", e.getMessage()));
+        }
+    }
+}

--- a/spring/src/main/java/com/example/spring/domain/cart/CartEntity.java
+++ b/spring/src/main/java/com/example/spring/domain/cart/CartEntity.java
@@ -1,0 +1,22 @@
+package com.example.spring.domain.cart;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Django {@code cart.Cart} → {@code cart_cart}
+ */
+@Entity
+@Table(name = "cart_cart")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CartEntity {
+
+    @Id
+    private Long id;
+
+    @Column(name = "table_usage_id", nullable = false)
+    private Long tableUsageId;
+}

--- a/spring/src/main/java/com/example/spring/domain/staffcall/StaffCall.java
+++ b/spring/src/main/java/com/example/spring/domain/staffcall/StaffCall.java
@@ -1,0 +1,72 @@
+package com.example.spring.domain.staffcall;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "staff_call")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StaffCall {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** JWT booth_id와 동일 — 조회/검증용 비정규화 */
+    @Column(name = "booth_id", nullable = false)
+    private Long boothId;
+
+    @Column(name = "table_id", nullable = false)
+    private Long tableId;
+
+    @Column(name = "cart_id", nullable = false)
+    private Long cartId;
+
+    /** 비즈니스 호출 종류(물, 계산서 등) */
+    @Column(name = "call_type", nullable = false, length = 64)
+    private String callType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false, length = 16)
+    private StaffCallCategory category;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 16)
+    private StaffCallStatus status;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "accepted_at")
+    private LocalDateTime acceptedAt;
+
+    @Column(name = "accepted_by", length = 255)
+    private String acceptedBy;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    @Version
+    @Column(name = "version")
+    private Long version;
+
+    @Builder
+    public StaffCall(Long boothId, Long tableId, Long cartId, String callType, StaffCallCategory category) {
+        this.boothId = boothId;
+        this.tableId = tableId;
+        this.cartId = cartId;
+        this.callType = callType;
+        this.category = category;
+        this.status = StaffCallStatus.PENDING;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public void accept(String acceptedBy) {
+        this.status = StaffCallStatus.ACCEPTED;
+        this.acceptedAt = LocalDateTime.now();
+        this.acceptedBy = acceptedBy;
+    }
+}

--- a/spring/src/main/java/com/example/spring/domain/staffcall/StaffCallCategory.java
+++ b/spring/src/main/java/com/example/spring/domain/staffcall/StaffCallCategory.java
@@ -1,0 +1,9 @@
+package com.example.spring.domain.staffcall;
+
+/**
+ * 서빙 연계 호출 vs 일반 직원 호출 구분 (Redis/WebSocket/API 공통)
+ */
+public enum StaffCallCategory {
+    SERVING,
+    GENERAL
+}

--- a/spring/src/main/java/com/example/spring/domain/staffcall/StaffCallStatus.java
+++ b/spring/src/main/java/com/example/spring/domain/staffcall/StaffCallStatus.java
@@ -1,0 +1,8 @@
+package com.example.spring.domain.staffcall;
+
+public enum StaffCallStatus {
+    PENDING,
+    ACCEPTED,
+    COMPLETED,
+    CANCELLED
+}

--- a/spring/src/main/java/com/example/spring/domain/table/BoothTable.java
+++ b/spring/src/main/java/com/example/spring/domain/table/BoothTable.java
@@ -1,0 +1,31 @@
+package com.example.spring.domain.table;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Django {@code table.Table} → DB 테이블 {@code table_table}
+ */
+@Entity
+@Table(name = "table_table")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BoothTable {
+
+    @Id
+    private Long id;
+
+    @Column(name = "booth_id", nullable = false)
+    private Long boothId;
+
+    @Column(name = "table_num", nullable = false)
+    private Integer tableNum;
+
+    /**
+     * Django: AVAILABLE, IN_USE, INACTIVE
+     */
+    @Column(name = "status", nullable = false, length = 20)
+    private String status;
+}

--- a/spring/src/main/java/com/example/spring/domain/table/TableUsageEntity.java
+++ b/spring/src/main/java/com/example/spring/domain/table/TableUsageEntity.java
@@ -1,0 +1,22 @@
+package com.example.spring.domain.table;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Django {@code table.TableUsage} → {@code table_tableusage}
+ */
+@Entity
+@Table(name = "table_tableusage")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TableUsageEntity {
+
+    @Id
+    private Long id;
+
+    @Column(name = "table_id", nullable = false)
+    private Long tableId;
+}

--- a/spring/src/main/java/com/example/spring/dto/redis/StaffCallRedisMessageDto.java
+++ b/spring/src/main/java/com/example/spring/dto/redis/StaffCallRedisMessageDto.java
@@ -1,0 +1,44 @@
+package com.example.spring.dto.redis;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * Redis 발행용 — category 로 serving / general 구분
+ */
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class StaffCallRedisMessageDto {
+
+    private String event;
+
+    @JsonProperty("staff_call_id")
+    private Long staffCallId;
+
+    @JsonProperty("booth_id")
+    private Long boothId;
+
+    @JsonProperty("table_id")
+    private Long tableId;
+
+    @JsonProperty("cart_id")
+    private Long cartId;
+
+    @JsonProperty("call_type")
+    private String callType;
+
+    /** SERVING | GENERAL */
+    private String category;
+
+    private String status;
+
+    @JsonProperty("pushed_at")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime pushedAt;
+}

--- a/spring/src/main/java/com/example/spring/dto/staffcall/request/StaffCallAcceptRequest.java
+++ b/spring/src/main/java/com/example/spring/dto/staffcall/request/StaffCallAcceptRequest.java
@@ -1,0 +1,13 @@
+package com.example.spring.dto.staffcall.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class StaffCallAcceptRequest {
+
+    private Long tableId;
+    private Long cartId;
+    private String callType;
+}

--- a/spring/src/main/java/com/example/spring/dto/staffcall/request/StaffCallEmitRequest.java
+++ b/spring/src/main/java/com/example/spring/dto/staffcall/request/StaffCallEmitRequest.java
@@ -1,0 +1,20 @@
+package com.example.spring.dto.staffcall.request;
+
+import com.example.spring.domain.staffcall.StaffCallCategory;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 직원 호출 발생(태블릿 등) — serving / general 구분
+ */
+@Getter
+@NoArgsConstructor
+public class StaffCallEmitRequest {
+
+    private Long tableId;
+    private Long cartId;
+    /** 예: WATER, BILL 등 */
+    private String callType;
+    /** SERVING: 서빙 연계, GENERAL: 일반 직원 호출 */
+    private StaffCallCategory category;
+}

--- a/spring/src/main/java/com/example/spring/dto/staffcall/request/StaffCallListRequest.java
+++ b/spring/src/main/java/com/example/spring/dto/staffcall/request/StaffCallListRequest.java
@@ -1,0 +1,16 @@
+package com.example.spring.dto.staffcall.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 은호님 의견: booth_id는 JWT로 충분 — 바디에서는 limit/offset(또는 cursor)만 사용
+ */
+@Getter
+@NoArgsConstructor
+public class StaffCallListRequest {
+
+    private int limit = 20;
+
+    private int offset = 0;
+}

--- a/spring/src/main/java/com/example/spring/dto/staffcall/response/StaffCallAcceptResponse.java
+++ b/spring/src/main/java/com/example/spring/dto/staffcall/response/StaffCallAcceptResponse.java
@@ -1,0 +1,31 @@
+package com.example.spring.dto.staffcall.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class StaffCallAcceptResponse {
+
+    @JsonProperty("table_id")
+    private Long tableId;
+
+    @JsonProperty("cart_id")
+    private Long cartId;
+
+    @JsonProperty("call_type")
+    private String callType;
+
+    private String status;
+
+    @JsonProperty("accepted_at")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime acceptedAt;
+
+    @JsonProperty("accepted_by")
+    private String acceptedBy;
+}

--- a/spring/src/main/java/com/example/spring/dto/staffcall/response/StaffCallItemResponse.java
+++ b/spring/src/main/java/com/example/spring/dto/staffcall/response/StaffCallItemResponse.java
@@ -1,0 +1,61 @@
+package com.example.spring.dto.staffcall.response;
+
+import com.example.spring.domain.staffcall.StaffCall;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class StaffCallItemResponse {
+
+    @JsonProperty("staff_call_id")
+    private Long staffCallId;
+
+    @JsonProperty("table_id")
+    private Long tableId;
+
+    @JsonProperty("cart_id")
+    private Long cartId;
+
+    @JsonProperty("call_type")
+    private String callType;
+
+    /** SERVING | GENERAL */
+    private String category;
+
+    private String status;
+
+    @JsonProperty("created_at")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime createdAt;
+
+    @JsonProperty("accepted_at")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime acceptedAt;
+
+    @JsonProperty("accepted_by")
+    private String acceptedBy;
+
+    @JsonProperty("completed_at")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime completedAt;
+
+    public static StaffCallItemResponse from(StaffCall sc) {
+        return StaffCallItemResponse.builder()
+                .staffCallId(sc.getId())
+                .tableId(sc.getTableId())
+                .cartId(sc.getCartId())
+                .callType(sc.getCallType())
+                .category(sc.getCategory() != null ? sc.getCategory().name() : null)
+                .status(sc.getStatus() != null ? sc.getStatus().name() : null)
+                .createdAt(sc.getCreatedAt())
+                .acceptedAt(sc.getAcceptedAt())
+                .acceptedBy(sc.getAcceptedBy())
+                .completedAt(sc.getCompletedAt())
+                .build();
+    }
+}

--- a/spring/src/main/java/com/example/spring/repository/cart/CartEntityRepository.java
+++ b/spring/src/main/java/com/example/spring/repository/cart/CartEntityRepository.java
@@ -1,0 +1,7 @@
+package com.example.spring.repository.cart;
+
+import com.example.spring.domain.cart.CartEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CartEntityRepository extends JpaRepository<CartEntity, Long> {
+}

--- a/spring/src/main/java/com/example/spring/repository/staffcall/StaffCallRepository.java
+++ b/spring/src/main/java/com/example/spring/repository/staffcall/StaffCallRepository.java
@@ -1,0 +1,47 @@
+package com.example.spring.repository.staffcall;
+
+import com.example.spring.domain.staffcall.StaffCall;
+import com.example.spring.domain.staffcall.StaffCallStatus;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface StaffCallRepository extends JpaRepository<StaffCall, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT sc FROM StaffCall sc WHERE sc.tableId = :tableId AND sc.cartId = :cartId AND sc.callType = :callType")
+    Optional<StaffCall> findByTableCartCallTypeForUpdate(
+            @Param("tableId") Long tableId,
+            @Param("cartId") Long cartId,
+            @Param("callType") String callType
+    );
+
+    @Query(value = """
+            SELECT sc.id, sc.booth_id, sc.table_id, sc.cart_id, sc.call_type, sc.category,
+                   sc.status, sc.created_at, sc.accepted_at, sc.accepted_by, sc.completed_at, sc.version
+            FROM staff_call sc
+            INNER JOIN table_table t ON sc.table_id = t.id
+            WHERE sc.booth_id = :boothId AND t.booth_id = :boothId
+            AND t.status IN ('AVAILABLE', 'IN_USE')
+            AND sc.status IN ('PENDING', 'ACCEPTED')
+            ORDER BY sc.created_at DESC
+            LIMIT :limit OFFSET :offset
+            """, nativeQuery = true)
+    List<StaffCall> findActiveCallsForBooth(
+            @Param("boothId") Long boothId,
+            @Param("limit") int limit,
+            @Param("offset") int offset
+    );
+
+    long countByTableIdAndCartIdAndCallTypeAndStatus(
+            Long tableId,
+            Long cartId,
+            String callType,
+            StaffCallStatus status
+    );
+}

--- a/spring/src/main/java/com/example/spring/repository/table/BoothTableRepository.java
+++ b/spring/src/main/java/com/example/spring/repository/table/BoothTableRepository.java
@@ -1,0 +1,11 @@
+package com.example.spring.repository.table;
+
+import com.example.spring.domain.table.BoothTable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BoothTableRepository extends JpaRepository<BoothTable, Long> {
+
+    Optional<BoothTable> findByIdAndBoothId(Long id, Long boothId);
+}

--- a/spring/src/main/java/com/example/spring/repository/table/TableUsageEntityRepository.java
+++ b/spring/src/main/java/com/example/spring/repository/table/TableUsageEntityRepository.java
@@ -1,0 +1,7 @@
+package com.example.spring.repository.table;
+
+import com.example.spring.domain.table.TableUsageEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TableUsageEntityRepository extends JpaRepository<TableUsageEntity, Long> {
+}

--- a/spring/src/main/java/com/example/spring/security/ServerApiJwtFilter.java
+++ b/spring/src/main/java/com/example/spring/security/ServerApiJwtFilter.java
@@ -1,0 +1,63 @@
+package com.example.spring.security;
+
+import com.example.spring.config.CookieUtil;
+import com.example.spring.config.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * {@code /server/**} 서버(직원) API — access_token 쿠키 필수
+ */
+@Component
+@RequiredArgsConstructor
+public class ServerApiJwtFilter extends OncePerRequestFilter {
+
+    public static final String ATTR_BOOTH_ID = "BOOTH_ID";
+
+    private final CookieUtil cookieUtil;
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String path = request.getRequestURI();
+        if (!path.startsWith("/server/")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = cookieUtil.getAccessTokenFromCookies(request.getCookies());
+        if (token == null || !jwtUtil.validateToken(token)) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+            response.getWriter().write("{\"message\":\"인증이 필요합니다.\"}");
+            return;
+        }
+        try {
+            Long boothId = jwtUtil.getBoothIdFromToken(token);
+            request.setAttribute(ATTR_BOOTH_ID, boothId);
+            request.setAttribute("ACCESS_TOKEN", token);
+        } catch (Exception e) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+            response.getWriter().write("{\"message\":\"유효하지 않은 토큰입니다.\"}");
+            return;
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/spring/src/main/java/com/example/spring/service/staffcall/StaffCallConflictException.java
+++ b/spring/src/main/java/com/example/spring/service/staffcall/StaffCallConflictException.java
@@ -1,0 +1,10 @@
+package com.example.spring.service.staffcall;
+
+/**
+ * 동시 수락 시 먼저 도달한 요청만 성공 — 나머지는 409
+ */
+public class StaffCallConflictException extends RuntimeException {
+    public StaffCallConflictException(String message) {
+        super(message);
+    }
+}

--- a/spring/src/main/java/com/example/spring/service/staffcall/StaffCallQueryService.java
+++ b/spring/src/main/java/com/example/spring/service/staffcall/StaffCallQueryService.java
@@ -1,0 +1,40 @@
+package com.example.spring.service.staffcall;
+
+import com.example.spring.domain.staffcall.StaffCall;
+import com.example.spring.dto.staffcall.response.StaffCallItemResponse;
+import com.example.spring.repository.staffcall.StaffCallRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class StaffCallQueryService {
+
+    private final StaffCallRepository staffCallRepository;
+
+    @Transactional(readOnly = true)
+    public Map<String, Object> listForBooth(Long boothId, int limit, int offset) {
+        int safeLimit = Math.min(Math.max(limit, 1), 200);
+        int safeOffset = Math.max(offset, 0);
+
+        List<StaffCall> page = staffCallRepository.findActiveCallsForBooth(boothId, safeLimit + 1, safeOffset);
+        boolean hasMore = page.size() > safeLimit;
+        List<StaffCall> slice = hasMore ? page.subList(0, safeLimit) : page;
+
+        List<StaffCallItemResponse> items = slice.stream()
+                .map(StaffCallItemResponse::from)
+                .collect(Collectors.toList());
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("message", "ok");
+        body.put("data", items);
+        body.put("has_more", hasMore);
+        return body;
+    }
+}

--- a/spring/src/main/java/com/example/spring/service/staffcall/StaffCallService.java
+++ b/spring/src/main/java/com/example/spring/service/staffcall/StaffCallService.java
@@ -1,0 +1,158 @@
+package com.example.spring.service.staffcall;
+
+import com.example.spring.config.JwtUtil;
+import com.example.spring.domain.cart.CartEntity;
+import com.example.spring.domain.staffcall.StaffCall;
+import com.example.spring.domain.staffcall.StaffCallStatus;
+import com.example.spring.domain.table.BoothTable;
+import com.example.spring.domain.table.TableUsageEntity;
+import com.example.spring.dto.redis.StaffCallRedisMessageDto;
+import com.example.spring.dto.staffcall.request.StaffCallAcceptRequest;
+import com.example.spring.dto.staffcall.request.StaffCallEmitRequest;
+import com.example.spring.dto.staffcall.response.StaffCallAcceptResponse;
+import com.example.spring.dto.staffcall.response.StaffCallItemResponse;
+import com.example.spring.repository.cart.CartEntityRepository;
+import com.example.spring.repository.staffcall.StaffCallRepository;
+import com.example.spring.repository.table.BoothTableRepository;
+import com.example.spring.repository.table.TableUsageEntityRepository;
+import com.example.spring.websocket.StaffCallWebSocketHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StaffCallService {
+
+    private final StaffCallRepository staffCallRepository;
+    private final StaffCallQueryService staffCallQueryService;
+    private final BoothTableRepository boothTableRepository;
+    private final CartEntityRepository cartEntityRepository;
+    private final TableUsageEntityRepository tableUsageEntityRepository;
+    private final JwtUtil jwtUtil;
+    private final ObjectMapper objectMapper;
+    private final StringRedisTemplate redisTemplate;
+
+    @Lazy
+    @Autowired
+    private StaffCallWebSocketHandler staffCallWebSocketHandler;
+
+    @Transactional
+    public StaffCallAcceptResponse accept(Long boothId, String accessToken, StaffCallAcceptRequest req) {
+        if (req.getTableId() == null || req.getCartId() == null || req.getCallType() == null) {
+            throw new IllegalArgumentException("table_id, cart_id, call_type은 필수입니다.");
+        }
+
+        StaffCall sc = staffCallRepository
+                .findByTableCartCallTypeForUpdate(req.getTableId(), req.getCartId(), req.getCallType())
+                .orElseThrow(() -> new IllegalArgumentException("해당 호출을 찾을 수 없습니다."));
+
+        if (!boothId.equals(sc.getBoothId())) {
+            throw new IllegalArgumentException("부스 정보가 일치하지 않습니다.");
+        }
+
+        if (sc.getStatus() != StaffCallStatus.PENDING) {
+            throw new StaffCallConflictException("이미 처리된 요청입니다.");
+        }
+
+        String acceptedBy = jwtUtil.getUsernameFromToken(accessToken);
+        if (acceptedBy == null || acceptedBy.isBlank()) {
+            acceptedBy = "unknown";
+        }
+
+        sc.accept(acceptedBy);
+
+        publishRedis(sc, "staff_call_accepted");
+        staffCallWebSocketHandler.broadcastSnapshot(boothId, staffCallQueryService.listForBooth(boothId, 50, 0));
+
+        return StaffCallAcceptResponse.builder()
+                .tableId(sc.getTableId())
+                .cartId(sc.getCartId())
+                .callType(sc.getCallType())
+                .status(sc.getStatus().name())
+                .acceptedAt(sc.getAcceptedAt())
+                .acceptedBy(sc.getAcceptedBy())
+                .build();
+    }
+
+    @Transactional
+    public Map<String, Object> emit(Long boothId, StaffCallEmitRequest req) {
+        if (req.getTableId() == null || req.getCartId() == null || req.getCallType() == null || req.getCategory() == null) {
+            throw new IllegalArgumentException("table_id, cart_id, call_type, category는 필수입니다.");
+        }
+
+        BoothTable table = boothTableRepository.findByIdAndBoothId(req.getTableId(), boothId)
+                .orElseThrow(() -> new IllegalArgumentException("테이블을 찾을 수 없거나 부스가 일치하지 않습니다."));
+
+        if (!"AVAILABLE".equals(table.getStatus()) && !"IN_USE".equals(table.getStatus())) {
+            throw new IllegalArgumentException("비활성 테이블에서는 호출할 수 없습니다.");
+        }
+
+        CartEntity cart = cartEntityRepository.findById(req.getCartId())
+                .orElseThrow(() -> new IllegalArgumentException("카트를 찾을 수 없습니다."));
+
+        TableUsageEntity usage = tableUsageEntityRepository.findById(cart.getTableUsageId())
+                .orElseThrow(() -> new IllegalArgumentException("테이블 사용 정보를 찾을 수 없습니다."));
+
+        if (!usage.getTableId().equals(req.getTableId())) {
+            throw new IllegalArgumentException("카트와 테이블이 일치하지 않습니다.");
+        }
+
+        long pendingDup = staffCallRepository.countByTableIdAndCartIdAndCallTypeAndStatus(
+                req.getTableId(), req.getCartId(), req.getCallType(), StaffCallStatus.PENDING);
+        if (pendingDup > 0) {
+            throw new StaffCallConflictException("동일한 호출이 이미 대기 중입니다.");
+        }
+
+        StaffCall sc = StaffCall.builder()
+                .boothId(boothId)
+                .tableId(req.getTableId())
+                .cartId(req.getCartId())
+                .callType(req.getCallType())
+                .category(req.getCategory())
+                .build();
+
+        staffCallRepository.save(sc);
+
+        publishRedis(sc, "staff_call_created");
+        staffCallWebSocketHandler.broadcastSnapshot(boothId, staffCallQueryService.listForBooth(boothId, 50, 0));
+
+        Map<String, Object> out = new HashMap<>();
+        out.put("message", "직원 호출이 등록되었습니다.");
+        out.put("data", StaffCallItemResponse.from(sc));
+        return out;
+    }
+
+    private void publishRedis(StaffCall sc, String event) {
+        try {
+            StaffCallRedisMessageDto dto = StaffCallRedisMessageDto.builder()
+                    .event(event)
+                    .staffCallId(sc.getId())
+                    .boothId(sc.getBoothId())
+                    .tableId(sc.getTableId())
+                    .cartId(sc.getCartId())
+                    .callType(sc.getCallType())
+                    .category(sc.getCategory() != null ? sc.getCategory().name() : null)
+                    .status(sc.getStatus() != null ? sc.getStatus().name() : null)
+                    .pushedAt(LocalDateTime.now())
+                    .build();
+
+            String json = objectMapper.writeValueAsString(dto);
+            String channel = "spring:booth:" + sc.getBoothId() + ":staffcall:" + event.replace("staff_call_", "");
+            redisTemplate.convertAndSend(channel, json);
+            log.info("[Redis staffcall] {}", channel);
+        } catch (Exception e) {
+            log.error("[Redis staffcall 발행 실패]", e);
+        }
+    }
+}

--- a/spring/src/main/java/com/example/spring/websocket/StaffCallWebSocketHandler.java
+++ b/spring/src/main/java/com/example/spring/websocket/StaffCallWebSocketHandler.java
@@ -1,0 +1,113 @@
+package com.example.spring.websocket;
+
+import com.example.spring.service.staffcall.StaffCallQueryService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.example.spring.config.StaffCallHandshakeInterceptor.ATTR_BOOTH_ID;
+
+/**
+ * 부스 단위 직원 호출 목록 — LIST 요청 및 서버 푸시(STAFF_CALL_SNAPSHOT)
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StaffCallWebSocketHandler extends TextWebSocketHandler {
+
+    private final StaffCallQueryService staffCallQueryService;
+    private final ObjectMapper objectMapper;
+
+    private final Map<Long, Set<WebSocketSession>> boothSessions = new ConcurrentHashMap<>();
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) {
+        Long boothId = (Long) session.getAttributes().get(ATTR_BOOTH_ID);
+        if (boothId == null) {
+            try {
+                session.close(CloseStatus.NOT_ACCEPTABLE);
+            } catch (IOException ignored) {
+            }
+            return;
+        }
+        boothSessions.computeIfAbsent(boothId, k -> ConcurrentHashMap.newKeySet()).add(session);
+        log.info("[staffcall ws] 연결 boothId={}, session={}", boothId, session.getId());
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
+        Long boothId = (Long) session.getAttributes().get(ATTR_BOOTH_ID);
+        if (boothId != null) {
+            Set<WebSocketSession> set = boothSessions.get(boothId);
+            if (set != null) {
+                set.remove(session);
+                if (set.isEmpty()) {
+                    boothSessions.remove(boothId);
+                }
+            }
+        }
+    }
+
+    @Override
+    protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+        Long boothId = (Long) session.getAttributes().get(ATTR_BOOTH_ID);
+        if (boothId == null) {
+            return;
+        }
+        JsonNode root = objectMapper.readTree(message.getPayload());
+        String type = root.path("type").asText("");
+        if (!"LIST".equalsIgnoreCase(type)) {
+            return;
+        }
+        int limit = root.path("limit").asInt(20);
+        int offset = root.path("offset").asInt(0);
+
+        Map<String, Object> snapshot = staffCallQueryService.listForBooth(boothId, limit, offset);
+        Map<String, Object> out = new HashMap<>();
+        out.put("type", "LIST_RESULT");
+        out.put("message", snapshot.get("message"));
+        out.put("data", snapshot.get("data"));
+        out.put("has_more", snapshot.get("has_more"));
+
+        session.sendMessage(new TextMessage(objectMapper.writeValueAsString(out)));
+    }
+
+    public void broadcastSnapshot(Long boothId, Map<String, Object> snapshot) {
+        Set<WebSocketSession> sessions = boothSessions.get(boothId);
+        if (sessions == null || sessions.isEmpty()) {
+            return;
+        }
+        try {
+            Map<String, Object> out = new HashMap<>();
+            out.put("type", "STAFF_CALL_SNAPSHOT");
+            out.put("message", snapshot.get("message"));
+            out.put("data", snapshot.get("data"));
+            out.put("has_more", snapshot.get("has_more"));
+            String json = objectMapper.writeValueAsString(out);
+            TextMessage tm = new TextMessage(json);
+            for (WebSocketSession s : sessions) {
+                if (s.isOpen()) {
+                    try {
+                        s.sendMessage(tm);
+                    } catch (IOException e) {
+                        log.warn("[staffcall ws] 전송 실패 session={}", s.getId(), e);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.error("[staffcall ws] broadcast 실패", e);
+        }
+    }
+}


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->

- Staff Call 서버 API (/server/**): JWT 쿠키(access_token) 기반 인증, Django SimpleJWT의 user_id에서 부스 ID 해석 (JwtUtil 보강)
- Staff Call REST (전부 POST): 요청 발행, 부스별 목록, 수락
- Redis 연동 및 WebSocket (/ws/server/staffcall)으로 STAFF_CALL_SNAPSHOT 브로드캐스트
- Nginx dev/prod에 Staff Call WebSocket 업그레이드 프록시 추가
- Staff Call 도메인·DTO·레포지토리, BoothTable / TableUsage / Cart 등 연동 엔티티·레포


## 📍 PR Point

<!-- 나 이 부분 찢었다~! -->

- /server 전용 ServerApiJwtFilter + SecurityConfig 등록으로 API와 인증 경계를 분리
- JwtUtil: booth_id 클레임이 없을 때 user_id로 부스 식별 (Django 기본 토큰과 호환)
- WebSocket 핸드셰이크에서 부스 검증 후 StaffCallWebSocketHandler로 라우팅, 서비스 레이어와 @Lazy로 순환 참조 완화
- Native 쿼리는 엔티티 매핑을 위해 필요한 컬럼만 명시 (예: category 등)

## 📢 Notices

 <!-- 공용으로 사용하는(Extension) 부분에 대한 설명 -->

JwtUtil, SecurityConfig, WebSocketConfig, nginx/dev.conf · nginx/prod.conf 는 다른 기능에서도 재사용·영향 가능한 공용 설정이므로 배포/리버스 프록시 경로 확인 권장

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #185
<!-- - ex) #3 -->