### PR TITLE
[Fix] #187 - Staff Call 호출 생성·수락은 비인증, 목록만 JWT

### DIFF
--- a/spring/src/main/java/com/example/spring/controller/staffcall/StaffCallController.java
+++ b/spring/src/main/java/com/example/spring/controller/staffcall/StaffCallController.java
@@ -28,12 +28,9 @@ public class StaffCallController {
      * 직원 호출 발생 — 경로를 {@code /staffcall/{boothId}} 보다 먼저 등록 (request가 boothId로 오인되지 않도록)
      */
     @PostMapping("/staffcall/request")
-    public ResponseEntity<Map<String, Object>> emit(
-            @RequestBody StaffCallEmitRequest body,
-            HttpServletRequest request) {
-        Long boothId = (Long) request.getAttribute(ServerApiJwtFilter.ATTR_BOOTH_ID);
+    public ResponseEntity<Map<String, Object>> emit(@RequestBody StaffCallEmitRequest body) {
         try {
-            return ResponseEntity.ok(staffCallService.emit(boothId, body));
+            return ResponseEntity.ok(staffCallService.emit(body));
         } catch (StaffCallConflictException e) {
             return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("message", e.getMessage()));
         } catch (IllegalArgumentException e) {
@@ -66,10 +63,9 @@ public class StaffCallController {
     public ResponseEntity<Map<String, Object>> accept(
             @RequestBody StaffCallAcceptRequest body,
             HttpServletRequest request) {
-        Long boothId = (Long) request.getAttribute(ServerApiJwtFilter.ATTR_BOOTH_ID);
         String accessToken = (String) request.getAttribute("ACCESS_TOKEN");
         try {
-            StaffCallAcceptResponse data = staffCallService.accept(boothId, accessToken, body);
+            StaffCallAcceptResponse data = staffCallService.accept(body, accessToken);
             return ResponseEntity.ok(Map.of(
                     "message", "호출을 수락했습니다.",
                     "data", data

--- a/spring/src/main/java/com/example/spring/security/ServerApiJwtFilter.java
+++ b/spring/src/main/java/com/example/spring/security/ServerApiJwtFilter.java
@@ -15,7 +15,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 /**
- * {@code /server/**} 서버(직원) API — access_token 쿠키 필수
+ * {@code /server/**} — Staff Call 목록({@code /staffcall/{boothId}})만 JWT 필수.
+ * 호출 생성({@code /staffcall/request})·수락({@code /accept})은 인증 없이 허용한다.
  */
 @Component
 @RequiredArgsConstructor
@@ -26,6 +27,11 @@ public class ServerApiJwtFilter extends OncePerRequestFilter {
     private final CookieUtil cookieUtil;
     private final JwtUtil jwtUtil;
 
+    /** 인증 생략: 호출 등록, 수락 */
+    private static boolean isStaffCallPublicPath(String path) {
+        return "/server/staffcall/request".equals(path) || "/server/accept".equals(path);
+    }
+
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
@@ -35,6 +41,11 @@ public class ServerApiJwtFilter extends OncePerRequestFilter {
             return;
         }
         if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if (isStaffCallPublicPath(path)) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/spring/src/main/java/com/example/spring/service/staffcall/StaffCallService.java
+++ b/spring/src/main/java/com/example/spring/service/staffcall/StaffCallService.java
@@ -48,7 +48,7 @@ public class StaffCallService {
     private StaffCallWebSocketHandler staffCallWebSocketHandler;
 
     @Transactional
-    public StaffCallAcceptResponse accept(Long boothId, String accessToken, StaffCallAcceptRequest req) {
+    public StaffCallAcceptResponse accept(StaffCallAcceptRequest req, String accessToken) {
         if (req.getTableId() == null || req.getCartId() == null || req.getCallType() == null) {
             throw new IllegalArgumentException("table_id, cart_id, call_type은 필수입니다.");
         }
@@ -57,15 +57,15 @@ public class StaffCallService {
                 .findByTableCartCallTypeForUpdate(req.getTableId(), req.getCartId(), req.getCallType())
                 .orElseThrow(() -> new IllegalArgumentException("해당 호출을 찾을 수 없습니다."));
 
-        if (!boothId.equals(sc.getBoothId())) {
-            throw new IllegalArgumentException("부스 정보가 일치하지 않습니다.");
-        }
+        Long boothId = sc.getBoothId();
 
         if (sc.getStatus() != StaffCallStatus.PENDING) {
             throw new StaffCallConflictException("이미 처리된 요청입니다.");
         }
 
-        String acceptedBy = jwtUtil.getUsernameFromToken(accessToken);
+        String acceptedBy = (accessToken != null && jwtUtil.validateToken(accessToken))
+                ? jwtUtil.getUsernameFromToken(accessToken)
+                : null;
         if (acceptedBy == null || acceptedBy.isBlank()) {
             acceptedBy = "unknown";
         }
@@ -86,13 +86,14 @@ public class StaffCallService {
     }
 
     @Transactional
-    public Map<String, Object> emit(Long boothId, StaffCallEmitRequest req) {
+    public Map<String, Object> emit(StaffCallEmitRequest req) {
         if (req.getTableId() == null || req.getCartId() == null || req.getCallType() == null || req.getCategory() == null) {
             throw new IllegalArgumentException("table_id, cart_id, call_type, category는 필수입니다.");
         }
 
-        BoothTable table = boothTableRepository.findByIdAndBoothId(req.getTableId(), boothId)
-                .orElseThrow(() -> new IllegalArgumentException("테이블을 찾을 수 없거나 부스가 일치하지 않습니다."));
+        BoothTable table = boothTableRepository.findById(req.getTableId())
+                .orElseThrow(() -> new IllegalArgumentException("테이블을 찾을 수 없습니다."));
+        Long boothId = table.getBoothId();
 
         if (!"AVAILABLE".equals(table.getStatus()) && !"IN_USE".equals(table.getStatus())) {
             throw new IllegalArgumentException("비활성 테이블에서는 호출할 수 없습니다.");


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->

/server/staffcall/request·/server/accept는 쿠키 없이 허용하고, /server/staffcall/{boothId}만 access_token 검증 및 부스 일치 확인. 호출 생성 시 booth_id는 table_id로 테이블 조회해 결정한다.

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #187 
<!-- - ex) #3 -->