### PR TITLE
🐛 [Fix] #189 - staff_call updated_at 매핑 및 스냅샷 실패 시 롤백 방지

### DIFF
--- a/spring/src/main/java/com/example/spring/domain/staffcall/StaffCall.java
+++ b/spring/src/main/java/com/example/spring/domain/staffcall/StaffCall.java
@@ -40,6 +40,9 @@ public class StaffCall {
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
     @Column(name = "accepted_at")
     private LocalDateTime acceptedAt;
 
@@ -61,12 +64,16 @@ public class StaffCall {
         this.callType = callType;
         this.category = category;
         this.status = StaffCallStatus.PENDING;
-        this.createdAt = LocalDateTime.now();
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
     }
 
     public void accept(String acceptedBy) {
         this.status = StaffCallStatus.ACCEPTED;
-        this.acceptedAt = LocalDateTime.now();
+        LocalDateTime now = LocalDateTime.now();
+        this.acceptedAt = now;
+        this.updatedAt = now;
         this.acceptedBy = acceptedBy;
     }
 }

--- a/spring/src/main/java/com/example/spring/repository/staffcall/StaffCallRepository.java
+++ b/spring/src/main/java/com/example/spring/repository/staffcall/StaffCallRepository.java
@@ -23,7 +23,7 @@ public interface StaffCallRepository extends JpaRepository<StaffCall, Long> {
 
     @Query(value = """
             SELECT sc.id, sc.booth_id, sc.table_id, sc.cart_id, sc.call_type, sc.category,
-                   sc.status, sc.created_at, sc.accepted_at, sc.accepted_by, sc.completed_at, sc.version
+                   sc.status, sc.created_at, sc.updated_at, sc.accepted_at, sc.accepted_by, sc.completed_at, sc.version
             FROM staff_call sc
             INNER JOIN table_table t ON sc.table_id = t.id
             WHERE sc.booth_id = :boothId AND t.booth_id = :boothId

--- a/spring/src/main/java/com/example/spring/service/staffcall/StaffCallService.java
+++ b/spring/src/main/java/com/example/spring/service/staffcall/StaffCallService.java
@@ -73,7 +73,11 @@ public class StaffCallService {
         sc.accept(acceptedBy);
 
         publishRedis(sc, "staff_call_accepted");
-        staffCallWebSocketHandler.broadcastSnapshot(boothId, staffCallQueryService.listForBooth(boothId, 50, 0));
+        try {
+            staffCallWebSocketHandler.broadcastSnapshot(boothId, staffCallQueryService.listForBooth(boothId, 50, 0));
+        } catch (Exception e) {
+            log.error("[staffcall accept] 스냅샷 조회/WS 푸시 실패 — 수락은 반영됨 boothId={}", boothId, e);
+        }
 
         return StaffCallAcceptResponse.builder()
                 .tableId(sc.getTableId())
@@ -126,7 +130,11 @@ public class StaffCallService {
         staffCallRepository.save(sc);
 
         publishRedis(sc, "staff_call_created");
-        staffCallWebSocketHandler.broadcastSnapshot(boothId, staffCallQueryService.listForBooth(boothId, 50, 0));
+        try {
+            staffCallWebSocketHandler.broadcastSnapshot(boothId, staffCallQueryService.listForBooth(boothId, 50, 0));
+        } catch (Exception e) {
+            log.error("[staffcall emit] 스냅샷 조회/WS 푸시 실패 — 호출 저장은 완료됨 boothId={}", boothId, e);
+        }
 
         Map<String, Object> out = new HashMap<>();
         out.put("message", "직원 호출이 등록되었습니다.");


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->
- StaffCall 엔티티에 updated_at 추가, 생성·수락 시 갱신
- findActiveCallsForBooth 네이티브 SELECT에 sc.updated_at 포함
- emit/accept 직후 스냅샷·WS 푸시 실패해도 DB 반영은 유지

## 📍 PR Point

<!-- 나 이 부분 찢었다~! -->
- DB 스키마(updated_at)와 엔티티·네이티브 SQL 컬럼 목록을 한 흐름으로 맞춤으로써, 호출 생성 직후 목록 조회에서 터지던 불일치를 제거했습니다.
- 스냅샷/푸시는 부가 동작으로 두고, 실패해도 핵심 트랜잭션(등록·수락)은 유지되도록 분리했습니다

## 📢 Notices

 <!-- 공용으로 사용하는(Extension) 부분에 대한 설명 -->

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #189
<!-- - ex) #3 -->