### PR TITLE
[♻️ refactor] #193 - ServingTask orderitem FK 제거 및 StaffCall JWT·부스 정합

### DIFF
--- a/spring/src/main/java/com/example/spring/controller/staffcall/StaffCallController.java
+++ b/spring/src/main/java/com/example/spring/controller/staffcall/StaffCallController.java
@@ -28,9 +28,12 @@ public class StaffCallController {
      * 직원 호출 발생 — 경로를 {@code /staffcall/{boothId}} 보다 먼저 등록 (request가 boothId로 오인되지 않도록)
      */
     @PostMapping("/staffcall/request")
-    public ResponseEntity<Map<String, Object>> emit(@RequestBody StaffCallEmitRequest body) {
+    public ResponseEntity<Map<String, Object>> emit(
+            @RequestBody StaffCallEmitRequest body,
+            HttpServletRequest request) {
+        Long boothId = (Long) request.getAttribute(ServerApiJwtFilter.ATTR_BOOTH_ID);
         try {
-            return ResponseEntity.ok(staffCallService.emit(body));
+            return ResponseEntity.ok(staffCallService.emit(boothId, body));
         } catch (StaffCallConflictException e) {
             return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("message", e.getMessage()));
         } catch (IllegalArgumentException e) {
@@ -63,9 +66,10 @@ public class StaffCallController {
     public ResponseEntity<Map<String, Object>> accept(
             @RequestBody StaffCallAcceptRequest body,
             HttpServletRequest request) {
+        Long boothId = (Long) request.getAttribute(ServerApiJwtFilter.ATTR_BOOTH_ID);
         String accessToken = (String) request.getAttribute("ACCESS_TOKEN");
         try {
-            StaffCallAcceptResponse data = staffCallService.accept(body, accessToken);
+            StaffCallAcceptResponse data = staffCallService.accept(boothId, accessToken, body);
             return ResponseEntity.ok(Map.of(
                     "message", "호출을 수락했습니다.",
                     "data", data

--- a/spring/src/main/java/com/example/spring/domain/serving/ServingTask.java
+++ b/spring/src/main/java/com/example/spring/domain/serving/ServingTask.java
@@ -1,6 +1,5 @@
 package com.example.spring.domain.serving;
 
-import com.example.spring.domain.orderitem.OrderItem;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
@@ -15,9 +14,8 @@ public class ServingTask {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "orderitem", nullable = false) // 🌟 중요: DB 실제 컬럼명이 orderitem 입니다.
-    private OrderItem orderItem;
+    @Column(name = "orderitem", nullable = false)
+    private Long orderItemId;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status")
@@ -45,8 +43,8 @@ public class ServingTask {
     private String key;
 
     @Builder
-    public ServingTask(OrderItem orderItem, String key) {
-        this.orderItem = orderItem;
+    public ServingTask(Long orderItemId, String key) {
+        this.orderItemId = orderItemId;
         this.status = ServingStatus.SERVE_REQUESTED;
         this.key = key;
         this.createdAt = LocalDateTime.now();

--- a/spring/src/main/java/com/example/spring/domain/staffcall/StaffCall.java
+++ b/spring/src/main/java/com/example/spring/domain/staffcall/StaffCall.java
@@ -40,9 +40,6 @@ public class StaffCall {
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
-
     @Column(name = "accepted_at")
     private LocalDateTime acceptedAt;
 
@@ -64,16 +61,12 @@ public class StaffCall {
         this.callType = callType;
         this.category = category;
         this.status = StaffCallStatus.PENDING;
-        LocalDateTime now = LocalDateTime.now();
-        this.createdAt = now;
-        this.updatedAt = now;
+        this.createdAt = LocalDateTime.now();
     }
 
     public void accept(String acceptedBy) {
         this.status = StaffCallStatus.ACCEPTED;
-        LocalDateTime now = LocalDateTime.now();
-        this.acceptedAt = now;
-        this.updatedAt = now;
+        this.acceptedAt = LocalDateTime.now();
         this.acceptedBy = acceptedBy;
     }
 }

--- a/spring/src/main/java/com/example/spring/dto/serving/response/CookedItemResponse.java
+++ b/spring/src/main/java/com/example/spring/dto/serving/response/CookedItemResponse.java
@@ -23,7 +23,7 @@ public class CookedItemResponse {
     public static CookedItemResponse from(ServingTask task) {
         return CookedItemResponse.builder()
                 .taskId(task.getId())
-                .orderItemId(task.getOrderItem().getId())
+                .orderItemId(task.getOrderItemId())
                 .status(task.getStatus().name())
                 .requestedAt(task.getRequestedAt())
                 .build();

--- a/spring/src/main/java/com/example/spring/dto/serving/response/ServingTaskResponse.java
+++ b/spring/src/main/java/com/example/spring/dto/serving/response/ServingTaskResponse.java
@@ -20,8 +20,7 @@ public class ServingTaskResponse {
     public static ServingTaskResponse from(ServingTask task) {
         return ServingTaskResponse.builder()
                 .taskId(task.getId())
-                // 만약 연관관계 매핑 에러로 orderItem이 null이면 여기서 터질 수 있습니다.
-                .orderItemId(task.getOrderItem() != null ? task.getOrderItem().getId() : null)
+                .orderItemId(task.getOrderItemId())
                 .status(task.getStatus() != null ? task.getStatus().name() : null)
                 .catchedBy(task.getCatchedBy())
                 .requestedAt(task.getRequestedAt())

--- a/spring/src/main/java/com/example/spring/repository/serving/ServingTaskRepository.java
+++ b/spring/src/main/java/com/example/spring/repository/serving/ServingTaskRepository.java
@@ -3,13 +3,10 @@ package com.example.spring.repository.serving;
 import com.example.spring.domain.serving.ServingStatus;
 import com.example.spring.domain.serving.ServingTask;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
+
 import java.util.List;
 
 public interface ServingTaskRepository extends JpaRepository<ServingTask, Long> {
 
-    // 🌟 join fetch를 사용하여 OrderItem 정보를 한 번의 쿼리로 묶어 가져옵니다.
-    @Query("SELECT st FROM ServingTask st JOIN FETCH st.orderItem WHERE st.status = :status")
-    List<ServingTask> findAllByStatusWithOrderItem(@Param("status") ServingStatus status);
+    List<ServingTask> findAllByStatus(ServingStatus status);
 }

--- a/spring/src/main/java/com/example/spring/repository/staffcall/StaffCallRepository.java
+++ b/spring/src/main/java/com/example/spring/repository/staffcall/StaffCallRepository.java
@@ -23,7 +23,7 @@ public interface StaffCallRepository extends JpaRepository<StaffCall, Long> {
 
     @Query(value = """
             SELECT sc.id, sc.booth_id, sc.table_id, sc.cart_id, sc.call_type, sc.category,
-                   sc.status, sc.created_at, sc.updated_at, sc.accepted_at, sc.accepted_by, sc.completed_at, sc.version
+                   sc.status, sc.created_at, sc.accepted_at, sc.accepted_by, sc.completed_at, sc.version
             FROM staff_call sc
             INNER JOIN table_table t ON sc.table_id = t.id
             WHERE sc.booth_id = :boothId AND t.booth_id = :boothId

--- a/spring/src/main/java/com/example/spring/security/ServerApiJwtFilter.java
+++ b/spring/src/main/java/com/example/spring/security/ServerApiJwtFilter.java
@@ -15,8 +15,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 /**
- * {@code /server/**} — Staff Call 목록({@code /staffcall/{boothId}})만 JWT 필수.
- * 호출 생성({@code /staffcall/request})·수락({@code /accept})은 인증 없이 허용한다.
+ * {@code /server/**} 서버(직원) API — access_token 쿠키 필수
  */
 @Component
 @RequiredArgsConstructor
@@ -27,11 +26,6 @@ public class ServerApiJwtFilter extends OncePerRequestFilter {
     private final CookieUtil cookieUtil;
     private final JwtUtil jwtUtil;
 
-    /** 인증 생략: 호출 등록, 수락 */
-    private static boolean isStaffCallPublicPath(String path) {
-        return "/server/staffcall/request".equals(path) || "/server/accept".equals(path);
-    }
-
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
@@ -41,11 +35,6 @@ public class ServerApiJwtFilter extends OncePerRequestFilter {
             return;
         }
         if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
-            filterChain.doFilter(request, response);
-            return;
-        }
-
-        if (isStaffCallPublicPath(path)) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/spring/src/main/java/com/example/spring/service/serving/ServingTaskEventListener.java
+++ b/spring/src/main/java/com/example/spring/service/serving/ServingTaskEventListener.java
@@ -1,6 +1,5 @@
 package com.example.spring.service.serving;
 
-import com.example.spring.domain.orderitem.OrderItem;
 import com.example.spring.domain.serving.ServingTask;
 import com.example.spring.dto.redis.OrderCookedMessageDto;
 import com.example.spring.dto.serving.response.ServingTaskResponse;
@@ -37,11 +36,11 @@ public class ServingTaskEventListener {
             try {
                 OrderCookedMessageDto dto = objectMapper.readValue(message, OrderCookedMessageDto.class);
 
-                OrderItem orderItem = orderItemRepository.findById(dto.getOrderItemId())
+                orderItemRepository.findById(dto.getOrderItemId())
                         .orElseThrow(() -> new IllegalArgumentException("OrderItem not found"));
 
                 ServingTask servingTask = ServingTask.builder()
-                        .orderItem(orderItem)
+                        .orderItemId(dto.getOrderItemId())
                         .key(UUID.randomUUID().toString())
                         .build();
 

--- a/spring/src/main/java/com/example/spring/service/serving/ServingTaskService.java
+++ b/spring/src/main/java/com/example/spring/service/serving/ServingTaskService.java
@@ -26,8 +26,7 @@ public class ServingTaskService {
     // 1. 부스별 서빙 요청 리스트 조회
     @Transactional(readOnly = true)
     public List<ServingTask> getPendingServingCalls(Long boothId) {
-        // 🌟 새로 만든 fetch join 메서드 호출
-        return servingTaskRepository.findAllByStatusWithOrderItem(ServingStatus.SERVE_REQUESTED);
+        return servingTaskRepository.findAllByStatus(ServingStatus.SERVE_REQUESTED);
     }
 
     // 2. 서빙 수락 (Catch)
@@ -39,7 +38,7 @@ public class ServingTaskService {
         task.acceptServing(catchedBy); // 상태 변경 (SERVING)
 
         // 장고로 상태 변경 메시지 발행
-        publishToDjango(boothId, "serving", task.getOrderItem().getId(), catchedBy);
+        publishToDjango(boothId, "serving", task.getOrderItemId(), catchedBy);
     }
 
     // 3. 서빙 완료
@@ -48,7 +47,7 @@ public class ServingTaskService {
         ServingTask task = servingTaskRepository.findById(taskId).orElseThrow();
         task.completeServing(); // 상태 변경 (SERVED)
 
-        publishToDjango(boothId, "served", task.getOrderItem().getId(), null);
+        publishToDjango(boothId, "served", task.getOrderItemId(), null);
     }
 
     // 4. 서빙 수락 취소
@@ -58,7 +57,7 @@ public class ServingTaskService {
         task.cancelServing(); // 상태 변경 (SERVE_REQUESTED 롤백)
 
         // 장고 측 OrderItem 상태도 다시 cooked로 롤백
-        publishToDjango(boothId, "cooked", task.getOrderItem().getId(), null);
+        publishToDjango(boothId, "cooked", task.getOrderItemId(), null);
     }
 
     // 장고가 구독 중인 채널로 Redis 메시지 발행

--- a/spring/src/main/java/com/example/spring/service/staffcall/StaffCallService.java
+++ b/spring/src/main/java/com/example/spring/service/staffcall/StaffCallService.java
@@ -48,7 +48,7 @@ public class StaffCallService {
     private StaffCallWebSocketHandler staffCallWebSocketHandler;
 
     @Transactional
-    public StaffCallAcceptResponse accept(StaffCallAcceptRequest req, String accessToken) {
+    public StaffCallAcceptResponse accept(Long boothId, String accessToken, StaffCallAcceptRequest req) {
         if (req.getTableId() == null || req.getCartId() == null || req.getCallType() == null) {
             throw new IllegalArgumentException("table_id, cart_id, call_type은 필수입니다.");
         }
@@ -57,15 +57,15 @@ public class StaffCallService {
                 .findByTableCartCallTypeForUpdate(req.getTableId(), req.getCartId(), req.getCallType())
                 .orElseThrow(() -> new IllegalArgumentException("해당 호출을 찾을 수 없습니다."));
 
-        Long boothId = sc.getBoothId();
+        if (!boothId.equals(sc.getBoothId())) {
+            throw new IllegalArgumentException("부스 정보가 일치하지 않습니다.");
+        }
 
         if (sc.getStatus() != StaffCallStatus.PENDING) {
             throw new StaffCallConflictException("이미 처리된 요청입니다.");
         }
 
-        String acceptedBy = (accessToken != null && jwtUtil.validateToken(accessToken))
-                ? jwtUtil.getUsernameFromToken(accessToken)
-                : null;
+        String acceptedBy = jwtUtil.getUsernameFromToken(accessToken);
         if (acceptedBy == null || acceptedBy.isBlank()) {
             acceptedBy = "unknown";
         }
@@ -73,11 +73,7 @@ public class StaffCallService {
         sc.accept(acceptedBy);
 
         publishRedis(sc, "staff_call_accepted");
-        try {
-            staffCallWebSocketHandler.broadcastSnapshot(boothId, staffCallQueryService.listForBooth(boothId, 50, 0));
-        } catch (Exception e) {
-            log.error("[staffcall accept] 스냅샷 조회/WS 푸시 실패 — 수락은 반영됨 boothId={}", boothId, e);
-        }
+        staffCallWebSocketHandler.broadcastSnapshot(boothId, staffCallQueryService.listForBooth(boothId, 50, 0));
 
         return StaffCallAcceptResponse.builder()
                 .tableId(sc.getTableId())
@@ -90,14 +86,13 @@ public class StaffCallService {
     }
 
     @Transactional
-    public Map<String, Object> emit(StaffCallEmitRequest req) {
+    public Map<String, Object> emit(Long boothId, StaffCallEmitRequest req) {
         if (req.getTableId() == null || req.getCartId() == null || req.getCallType() == null || req.getCategory() == null) {
             throw new IllegalArgumentException("table_id, cart_id, call_type, category는 필수입니다.");
         }
 
-        BoothTable table = boothTableRepository.findById(req.getTableId())
-                .orElseThrow(() -> new IllegalArgumentException("테이블을 찾을 수 없습니다."));
-        Long boothId = table.getBoothId();
+        BoothTable table = boothTableRepository.findByIdAndBoothId(req.getTableId(), boothId)
+                .orElseThrow(() -> new IllegalArgumentException("테이블을 찾을 수 없거나 부스가 일치하지 않습니다."));
 
         if (!"AVAILABLE".equals(table.getStatus()) && !"IN_USE".equals(table.getStatus())) {
             throw new IllegalArgumentException("비활성 테이블에서는 호출할 수 없습니다.");
@@ -130,11 +125,7 @@ public class StaffCallService {
         staffCallRepository.save(sc);
 
         publishRedis(sc, "staff_call_created");
-        try {
-            staffCallWebSocketHandler.broadcastSnapshot(boothId, staffCallQueryService.listForBooth(boothId, 50, 0));
-        } catch (Exception e) {
-            log.error("[staffcall emit] 스냅샷 조회/WS 푸시 실패 — 호출 저장은 완료됨 boothId={}", boothId, e);
-        }
+        staffCallWebSocketHandler.broadcastSnapshot(boothId, staffCallQueryService.listForBooth(boothId, 50, 0));
 
         Map<String, Object> out = new HashMap<>();
         out.put("message", "직원 호출이 등록되었습니다.");


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->
ServingTask는 Django 소유 orderitem에 JPA FK를 두지 않고 Long orderItemId만 매핑한다. Repository·서비스·DTO·Redis 리스너를 ID 기준으로 맞춘다.

StaffCall emit/accept는 access_token 필수로 통일하고 booth_id는 JWT에서만 전달한다. emit 시 테이블은 부스와 함께 검증한다. StaffCall 엔티티와 목록 네이티브 쿼리에서 updated_at 컬럼을 제거한다. accept 시 스냅샷 WS try/catch를 제거한다.

## 📍 PR Point

<!-- 나 이 부분 찢었다~! -->

공유 DB에서 Django가 소유한 orderitem에 Spring이 FK를 관리하려다 생기던 권한/DDL 이슈를 피하기 위해, 서빙 쪽은 참조를 ID 컬럼만 두는 방향으로 정리한 부분

StaffCall은 토큰 없이 emit/accept 하던 예외 경로를 없애고, JWT의 booth와 요청 본문의 리소스가 일치하는지 서비스에서 검증하는 부분

## 📢 Notices

 <!-- 공용으로 사용하는(Extension) 부분에 대한 설명 -->

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #193
<!-- - ex) #3 -->