### PR TITLE
🐛 [Fix] #195 - accept 인증 복구, emit만 무인증으로 분리

### DIFF
--- a/spring/src/main/java/com/example/spring/controller/staffcall/StaffCallController.java
+++ b/spring/src/main/java/com/example/spring/controller/staffcall/StaffCallController.java
@@ -8,13 +8,13 @@ import com.example.spring.security.ServerApiJwtFilter;
 import com.example.spring.service.staffcall.StaffCallConflictException;
 import com.example.spring.service.staffcall.StaffCallQueryService;
 import com.example.spring.service.staffcall.StaffCallService;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
+import jakarta.servlet.http.HttpServletRequest;
 
 @RestController
 @RequestMapping("/server")
@@ -29,11 +29,9 @@ public class StaffCallController {
      */
     @PostMapping("/staffcall/request")
     public ResponseEntity<Map<String, Object>> emit(
-            @RequestBody StaffCallEmitRequest body,
-            HttpServletRequest request) {
-        Long boothId = (Long) request.getAttribute(ServerApiJwtFilter.ATTR_BOOTH_ID);
+            @RequestBody StaffCallEmitRequest body) {
         try {
-            return ResponseEntity.ok(staffCallService.emit(boothId, body));
+            return ResponseEntity.ok(staffCallService.emit(body));
         } catch (StaffCallConflictException e) {
             return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("message", e.getMessage()));
         } catch (IllegalArgumentException e) {
@@ -66,9 +64,9 @@ public class StaffCallController {
     public ResponseEntity<Map<String, Object>> accept(
             @RequestBody StaffCallAcceptRequest body,
             HttpServletRequest request) {
-        Long boothId = (Long) request.getAttribute(ServerApiJwtFilter.ATTR_BOOTH_ID);
-        String accessToken = (String) request.getAttribute("ACCESS_TOKEN");
         try {
+            Long boothId = (Long) request.getAttribute(ServerApiJwtFilter.ATTR_BOOTH_ID);
+            String accessToken = (String) request.getAttribute("ACCESS_TOKEN");
             StaffCallAcceptResponse data = staffCallService.accept(boothId, accessToken, body);
             return ResponseEntity.ok(Map.of(
                     "message", "호출을 수락했습니다.",

--- a/spring/src/main/java/com/example/spring/security/ServerApiJwtFilter.java
+++ b/spring/src/main/java/com/example/spring/security/ServerApiJwtFilter.java
@@ -15,7 +15,9 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 /**
- * {@code /server/**} 서버(직원) API — access_token 쿠키 필수
+ * {@code /server/**} 서버(직원) API — (기본) access_token 쿠키 필수
+ * <p>
+ * 단, 직원 호출 등록(emit)은 인증을 강제하지 않음
  */
 @Component
 @RequiredArgsConstructor
@@ -35,6 +37,12 @@ public class ServerApiJwtFilter extends OncePerRequestFilter {
             return;
         }
         if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 직원 호출 등록(emit)만 인증을 강제하지 않음
+        if (isStaffCallPublicPath(path)) {
             filterChain.doFilter(request, response);
             return;
         }
@@ -59,5 +67,9 @@ public class ServerApiJwtFilter extends OncePerRequestFilter {
             return;
         }
         filterChain.doFilter(request, response);
+    }
+
+    private boolean isStaffCallPublicPath(String path) {
+        return "/server/staffcall/request".equals(path);
     }
 }

--- a/spring/src/main/java/com/example/spring/service/staffcall/StaffCallService.java
+++ b/spring/src/main/java/com/example/spring/service/staffcall/StaffCallService.java
@@ -86,13 +86,14 @@ public class StaffCallService {
     }
 
     @Transactional
-    public Map<String, Object> emit(Long boothId, StaffCallEmitRequest req) {
+    public Map<String, Object> emit(StaffCallEmitRequest req) {
         if (req.getTableId() == null || req.getCartId() == null || req.getCallType() == null || req.getCategory() == null) {
             throw new IllegalArgumentException("table_id, cart_id, call_type, category는 필수입니다.");
         }
 
-        BoothTable table = boothTableRepository.findByIdAndBoothId(req.getTableId(), boothId)
-                .orElseThrow(() -> new IllegalArgumentException("테이블을 찾을 수 없거나 부스가 일치하지 않습니다."));
+        BoothTable table = boothTableRepository.findById(req.getTableId())
+                .orElseThrow(() -> new IllegalArgumentException("테이블을 찾을 수 없습니다."));
+        Long boothId = table.getBoothId();
 
         if (!"AVAILABLE".equals(table.getStatus()) && !"IN_USE".equals(table.getStatus())) {
             throw new IllegalArgumentException("비활성 테이블에서는 호출할 수 없습니다.");


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->
- erverApiJwtFilter에서 POST /server/staffcall/request (emit) 경로만 JWT 쿠키 인증을 bypass하도록 수정
- POST /server/accept (accept) 경로는 기존대로 JWT 쿠키 인증을 요구하도록 유지
- StaffCallController / StaffCallService의 로직을 accept 기준으로 다시 정합성 맞춤

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #195
<!-- - ex) #3 -->