### PR TITLE
🐛 [Fix] - coupon 운영진 권한 설정

### DIFF
--- a/django/coupon/views.py
+++ b/django/coupon/views.py
@@ -24,18 +24,15 @@ def error_response(e: CouponError):
 
 
 def get_admin_booth(request) -> Booth:
-    if not request.user.is_staff:
-        raise CouponError("권한이 없습니다.", error_code="FORBIDDEN", detail="admin only", status_code=403)
-
-    try:
-        return request.user.booth
-    except Booth.DoesNotExist:
+    booth = getattr(request.user, "booth", None)
+    if not booth:
         raise CouponError(
             "운영자 부스 정보를 찾을 수 없습니다.",
             error_code="BOOTH_NOT_FOUND",
             detail="user has no booth mapped",
             status_code=404,
         )
+    return booth
 
 
 # 운영자용: 쿠폰 목록/등록


### PR DESCRIPTION
## 🔍 What is the PR?
- 쿠폰 API의 운영자 권한 검증 로직 수정
- 기존 is_staff 기반 권한 체크 제거
- request.user.booth 기반으로 권한 검증 방식 변경

## 📍 PR Point
- 기존 쿠폰 API는 request.user.is_staff를 기준으로 권한을 더블 체크하고 있었지만, booth 연결 여부로 판단 동일하게 바

## 📢 Notices
- 쿠폰 API는 더 이상 is_staff 값을 사용하지 않음
- 운영자 판별 기준: 로그인 상태 / user.booth 존재 여부

## ✅ Check List
- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues
#198 