### PR TITLE
🐛 [Fix] #200 - staff_call updated_at NOT NULL 반영

### DIFF
--- a/spring/src/main/java/com/example/spring/domain/staffcall/StaffCall.java
+++ b/spring/src/main/java/com/example/spring/domain/staffcall/StaffCall.java
@@ -40,6 +40,9 @@ public class StaffCall {
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
     @Column(name = "accepted_at")
     private LocalDateTime acceptedAt;
 
@@ -62,11 +65,13 @@ public class StaffCall {
         this.category = category;
         this.status = StaffCallStatus.PENDING;
         this.createdAt = LocalDateTime.now();
+        this.updatedAt = this.createdAt;
     }
 
     public void accept(String acceptedBy) {
         this.status = StaffCallStatus.ACCEPTED;
         this.acceptedAt = LocalDateTime.now();
         this.acceptedBy = acceptedBy;
+        this.updatedAt = this.acceptedAt;
     }
 }

--- a/spring/src/main/java/com/example/spring/repository/staffcall/StaffCallRepository.java
+++ b/spring/src/main/java/com/example/spring/repository/staffcall/StaffCallRepository.java
@@ -23,7 +23,7 @@ public interface StaffCallRepository extends JpaRepository<StaffCall, Long> {
 
     @Query(value = """
             SELECT sc.id, sc.booth_id, sc.table_id, sc.cart_id, sc.call_type, sc.category,
-                   sc.status, sc.created_at, sc.accepted_at, sc.accepted_by, sc.completed_at, sc.version
+                   sc.status, sc.created_at, sc.updated_at, sc.accepted_at, sc.accepted_by, sc.completed_at, sc.version
             FROM staff_call sc
             INNER JOIN table_table t ON sc.table_id = t.id
             WHERE sc.booth_id = :boothId AND t.booth_id = :boothId

--- a/spring/src/main/java/com/example/spring/service/staffcall/StaffCallService.java
+++ b/spring/src/main/java/com/example/spring/service/staffcall/StaffCallService.java
@@ -73,7 +73,12 @@ public class StaffCallService {
         sc.accept(acceptedBy);
 
         publishRedis(sc, "staff_call_accepted");
-        staffCallWebSocketHandler.broadcastSnapshot(boothId, staffCallQueryService.listForBooth(boothId, 50, 0));
+        try {
+            staffCallWebSocketHandler.broadcastSnapshot(boothId,
+                    staffCallQueryService.listForBooth(boothId, 50, 0));
+        } catch (Exception e) {
+            log.error("[staffcall accept] 스냅샷 조회/WS 푸시 실패 — 수락은 반영됨 boothId={}", boothId, e);
+        }
 
         return StaffCallAcceptResponse.builder()
                 .tableId(sc.getTableId())
@@ -91,14 +96,6 @@ public class StaffCallService {
             throw new IllegalArgumentException("table_id, cart_id, call_type, category는 필수입니다.");
         }
 
-        BoothTable table = boothTableRepository.findById(req.getTableId())
-                .orElseThrow(() -> new IllegalArgumentException("테이블을 찾을 수 없습니다."));
-        Long boothId = table.getBoothId();
-
-        if (!"AVAILABLE".equals(table.getStatus()) && !"IN_USE".equals(table.getStatus())) {
-            throw new IllegalArgumentException("비활성 테이블에서는 호출할 수 없습니다.");
-        }
-
         CartEntity cart = cartEntityRepository.findById(req.getCartId())
                 .orElseThrow(() -> new IllegalArgumentException("카트를 찾을 수 없습니다."));
 
@@ -109,15 +106,26 @@ public class StaffCallService {
             throw new IllegalArgumentException("카트와 테이블이 일치하지 않습니다.");
         }
 
+        // 요청 body의 tableId가 부정확할 수 있으므로, cart->tableUsage으로 확정한 실제 tableId로 테이블을 조회한다.
+        Long actualTableId = usage.getTableId();
+
+        BoothTable table = boothTableRepository.findById(actualTableId)
+                .orElseThrow(() -> new IllegalArgumentException("테이블을 찾을 수 없습니다."));
+        Long boothId = table.getBoothId();
+
+        if (!"AVAILABLE".equals(table.getStatus()) && !"IN_USE".equals(table.getStatus())) {
+            throw new IllegalArgumentException("비활성 테이블에서는 호출할 수 없습니다.");
+        }
+
         long pendingDup = staffCallRepository.countByTableIdAndCartIdAndCallTypeAndStatus(
-                req.getTableId(), req.getCartId(), req.getCallType(), StaffCallStatus.PENDING);
+                actualTableId, req.getCartId(), req.getCallType(), StaffCallStatus.PENDING);
         if (pendingDup > 0) {
             throw new StaffCallConflictException("동일한 호출이 이미 대기 중입니다.");
         }
 
         StaffCall sc = StaffCall.builder()
                 .boothId(boothId)
-                .tableId(req.getTableId())
+                .tableId(actualTableId)
                 .cartId(req.getCartId())
                 .callType(req.getCallType())
                 .category(req.getCategory())
@@ -126,7 +134,14 @@ public class StaffCallService {
         staffCallRepository.save(sc);
 
         publishRedis(sc, "staff_call_created");
-        staffCallWebSocketHandler.broadcastSnapshot(boothId, staffCallQueryService.listForBooth(boothId, 50, 0));
+        try {
+            staffCallWebSocketHandler.broadcastSnapshot(boothId,
+                    staffCallQueryService.listForBooth(boothId, 50, 0));
+        } catch (Exception e) {
+            // 호출 생성/수락은 저장 트랜잭션에 포함된 비즈니스 결과이므로
+            // WS 스냅샷 실패가 전체 요청을 500으로 만들지 않도록 예외를 삼킨다.
+            log.error("[staffcall emit] 스냅샷 조회/WS 푸시 실패 — 호출 저장은 반영됨 boothId={}", boothId, e);
+        }
 
         Map<String, Object> out = new HashMap<>();
         out.put("message", "직원 호출이 등록되었습니다.");


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->
- staff_call.updated_at 컬럼이 DB에서 NOT NULL인데, Spring StaffCall 엔티티에 updatedAt 매핑이 없어 insert 시 updated_at=null이 들어가며 500이 발생하던 문제를 수정
- StaffCall에 updated_at 필드를 추가하고 생성/수락 시 updatedAt을 세팅
- StaffCallRepository.findActiveCallsForBooth native query에 sc.updated_at을 포함시켜 조회 DTO 매핑 정합성까지 맞춤

## 📍 PR Point

<!-- 나 이 부분 찢었다~! -->

- DB 제약(NOT NULL)과 JPA 엔티티 매핑 불일치로 인해 생기던 insert 실패/500 제거
- staff_call의 변경 시각(updated_at)을 애플리케이션 레벨에서 일관되게 관리하도록 정리

## 📢 Notices

 <!-- 공용으로 사용하는(Extension) 부분에 대한 설명 -->

- 이 변경은 staff_call.updated_at이 실제로 NOT NULL인 스키마를 전제로 동작함
- native query 결과 컬럼 구성 변경이 포함되어 있어, 배포 시 staff_call 컬럼명/타입이 동일한지 확인 필요

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #200
<!-- - ex) #3 -->