### PR TITLE
🐛 [fix] - 장바구니 수량 변경 에러 수정

### DIFF
--- a/django/cart/services.py
+++ b/django/cart/services.py
@@ -93,7 +93,7 @@ def update_item_quantity(*, table_usage_id: int, cart_item_id: int, quantity: in
         )
 
     item = get_object_or_404(
-        CartItem.objects.select_for_update().select_related("menu", "setmenu"),
+        CartItem.objects.select_for_update(),
         id=cart_item_id,
         cart=cart,
     )


### PR DESCRIPTION
## 🔍 What is the PR?
- 장바구니 수량 변경 API(PATCH /api/v3/django/cart/menu/) 호출 시 발생하던 500 에러 수정
- select_for_update()와 select_related()를 함께 사용하면서 발생한 PostgreSQL 에러 해결
- CartItem 조회 시 nullable FK(menu, setmenu)에 대한 outer join 문제 제거


## 📍 PR Point
- CartItem.objects.select_for_update().select_related(...) → select_for_update() 단독 사용으로 수정


## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues
#192 