### PR TITLE
🐛 [Fix] #203 - JWT Django 의존 해결

### DIFF
--- a/spring/src/main/java/com/example/spring/config/JwtUtil.java
+++ b/spring/src/main/java/com/example/spring/config/JwtUtil.java
@@ -120,6 +120,9 @@ public class JwtUtil {
             log.warn("지원하지 않는 JWT 토큰입니다: {}", e.getMessage());
         } catch (MalformedJwtException e) {
             log.warn("잘못된 JWT 토큰입니다: {}", e.getMessage());
+        } catch (io.jsonwebtoken.security.SignatureException e) {
+            // io.jsonwebtoken.security.SignatureException은 SecurityException을 상속하지 않음
+            log.warn("JWT 서명이 유효하지 않습니다: {}", e.getMessage());
         } catch (SecurityException e) {
             log.warn("JWT 서명이 유효하지 않습니다: {}", e.getMessage());
         } catch (IllegalArgumentException e) {

--- a/spring/src/main/java/com/example/spring/repository/staffcall/StaffCallRepository.java
+++ b/spring/src/main/java/com/example/spring/repository/staffcall/StaffCallRepository.java
@@ -25,9 +25,7 @@ public interface StaffCallRepository extends JpaRepository<StaffCall, Long> {
             SELECT sc.id, sc.booth_id, sc.table_id, sc.cart_id, sc.call_type, sc.category,
                    sc.status, sc.created_at, sc.updated_at, sc.accepted_at, sc.accepted_by, sc.completed_at, sc.version
             FROM staff_call sc
-            INNER JOIN table_table t ON sc.table_id = t.id
-            WHERE sc.booth_id = :boothId AND t.booth_id = :boothId
-            AND t.status IN ('AVAILABLE', 'IN_USE')
+            WHERE sc.booth_id = :boothId
             AND sc.status IN ('PENDING', 'ACCEPTED')
             ORDER BY sc.created_at DESC
             LIMIT :limit OFFSET :offset


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->
JWT 검증 시 SignatureException을 별도로 처리해 서명 불일치 상황에서 500 대신 인증 실패로 처리되도록 수정
StaffCall active-calls 조회 쿼리에서 Django table_table 조인/테이블 상태 조건을 제거하고, staff_call의 booth_id + status(PENDING/ACCEPTED) 기준으로 목록 조회하도록 단순화

## 📍 PR Point

<!-- 나 이 부분 찢었다~! -->

Django 테이블 상태/조인 의존 제거
로 Spring StaffCall 목록 조회가 Django 스키마/상태에 덜 취약해짐

JWT 서명 불일치(환경별 SECRET_KEY 차이 등)
케이스가 500으로 번지지 않도록 방어

## 📢 Notices

 <!-- 공용으로 사용하는(Extension) 부분에 대한 설명 -->

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #203
<!-- - ex) #3 -->