### PR TITLE
🐛 [Fix] #206 - 시크릿 키 크기 문제 해결

### DIFF
--- a/spring/src/main/java/com/example/spring/config/JwtUtil.java
+++ b/spring/src/main/java/com/example/spring/config/JwtUtil.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
@@ -22,12 +23,16 @@ public class JwtUtil {
     private final JwtProperties jwtProperties;
 
     /**
-     * SecretKey 생성
-     * Django와 동일한 SECRET_KEY 사용
+     * SecretKey 생성 — Django SimpleJWT / PyJWT와 동일한 바이트열로 HMAC.
+     * jjwt 0.12의 {@link Keys#hmacShaKeyFor}는 256비트 미만 키를 거부하지만,
+     * PyJWT는 짧은 SECRET_KEY로도 서명하므로 그 경우 {@link SecretKeySpec}으로 맞춘다.
      */
     private SecretKey getSigningKey() {
         byte[] keyBytes = jwtProperties.getSecretKey().getBytes(StandardCharsets.UTF_8);
-        return Keys.hmacShaKeyFor(keyBytes);
+        if (keyBytes.length >= 32) {
+            return Keys.hmacShaKeyFor(keyBytes);
+        }
+        return new SecretKeySpec(keyBytes, "HmacSHA256");
     }
 
     /**


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->
- jjwt 0.12의 `Keys.hmacShaKeyFor()`는 HMAC용 키가 256비트(32바이트) 미만이면 `WeakKeyException`을 발생시킨다.
- dev 등에서 `SECRET_KEY`가 짧을 때, JWT 필터(`ServerApiJwtFilter`)에서 토큰 검증 중 예외가 처리되지 않고 올라가 `/server/staffcall/{id}` 등 서버 API가 **500**으로 실패했다.
- Django(SimpleJWT) / PyJWT는 동일한 짧은 `SECRET_KEY`로도 서명·검증이 가능해, **Spring만** 실패하는 불일치가 있었다.
- 키 길이가 32바이트 이상이면 기존처럼 `Keys.hmacShaKeyFor`를 쓰고, 미만이면 Django와 같은 바이트열로 `SecretKeySpec(..., "HmacSHA256")`을 사용하도록 `JwtUtil#getSigningKey()`를 분기했다

## 📢 Notices

 <!-- 공용으로 사용하는(Extension) 부분에 대한 설명 -->
- `JwtUtil`은 Django와 **같은 `SECRET_KEY` 문자열**을 쓰는 전제는 그대로다. 변경은 “짧을 때 키 객체를 어떻게 만들지”에 한정된다.
- 보안·운영 측면에서는 여전히 **32바이트 이상의 강한 `SECRET_KEY` 사용**을 권장한다.

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #206
<!-- - ex) #3 -->