### PR TITLE
✨ [Feat] #210 - staff call funtion 고도화

### DIFF
--- a/spring/src/main/java/com/example/spring/config/WebSocketConfig.java
+++ b/spring/src/main/java/com/example/spring/config/WebSocketConfig.java
@@ -1,6 +1,7 @@
 package com.example.spring.config;
 
 import com.example.spring.websocket.ServingWebSocketHandler;
+import com.example.spring.websocket.CustomerStaffCallWebSocketHandler;
 import com.example.spring.websocket.StaffCallWebSocketHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
@@ -16,6 +17,7 @@ public class WebSocketConfig implements WebSocketConfigurer {
 
     private final ServingWebSocketHandler servingWebSocketHandler;
     private final StaffCallWebSocketHandler staffCallWebSocketHandler;
+    private final CustomerStaffCallWebSocketHandler customerStaffCallWebSocketHandler;
     private final StaffCallHandshakeInterceptor staffCallHandshakeInterceptor;
 
     @Override
@@ -37,5 +39,14 @@ public class WebSocketConfig implements WebSocketConfigurer {
                         "https://*.dorder-api.shop"
                 )
                 .addInterceptors(staffCallHandshakeInterceptor, new HttpSessionHandshakeInterceptor());
+
+        registry.addHandler(customerStaffCallWebSocketHandler, "/ws/customer/staffcall")
+                .setAllowedOriginPatterns(
+                        "http://localhost:5173",
+                        "https://dev.dorder-api.shop",
+                        "http://dev.dorder-api.shop",
+                        "https://*.dorder-api.shop"
+                )
+                .addInterceptors(new HttpSessionHandshakeInterceptor());
     }
 }

--- a/spring/src/main/java/com/example/spring/controller/staffcall/StaffCallController.java
+++ b/spring/src/main/java/com/example/spring/controller/staffcall/StaffCallController.java
@@ -1,6 +1,7 @@
 package com.example.spring.controller.staffcall;
 
 import com.example.spring.dto.staffcall.request.StaffCallAcceptRequest;
+import com.example.spring.dto.staffcall.request.StaffCallCancelRequest;
 import com.example.spring.dto.staffcall.request.StaffCallEmitRequest;
 import com.example.spring.dto.staffcall.request.StaffCallListRequest;
 import com.example.spring.dto.staffcall.response.StaffCallAcceptResponse;
@@ -72,6 +73,24 @@ public class StaffCallController {
                     "message", "호출을 수락했습니다.",
                     "data", data
             ));
+        } catch (StaffCallConflictException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("message", e.getMessage()));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("message", e.getMessage()));
+        }
+    }
+
+    /**
+     * POST /api/v3/spring/server/staffcall/cancel
+     */
+    @PostMapping("/staffcall/cancel")
+    public ResponseEntity<Map<String, Object>> cancelAccept(
+            @RequestBody StaffCallCancelRequest body,
+            HttpServletRequest request) {
+        try {
+            Long boothId = (Long) request.getAttribute(ServerApiJwtFilter.ATTR_BOOTH_ID);
+            String accessToken = (String) request.getAttribute("ACCESS_TOKEN");
+            return ResponseEntity.ok(staffCallService.cancelAccept(boothId, accessToken, body));
         } catch (StaffCallConflictException e) {
             return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("message", e.getMessage()));
         } catch (IllegalArgumentException e) {

--- a/spring/src/main/java/com/example/spring/domain/staffcall/StaffCall.java
+++ b/spring/src/main/java/com/example/spring/domain/staffcall/StaffCall.java
@@ -74,4 +74,11 @@ public class StaffCall {
         this.acceptedBy = acceptedBy;
         this.updatedAt = this.acceptedAt;
     }
+
+    public void unaccept() {
+        this.status = StaffCallStatus.PENDING;
+        this.acceptedAt = null;
+        this.acceptedBy = null;
+        this.updatedAt = LocalDateTime.now();
+    }
 }

--- a/spring/src/main/java/com/example/spring/dto/staffcall/request/StaffCallCancelRequest.java
+++ b/spring/src/main/java/com/example/spring/dto/staffcall/request/StaffCallCancelRequest.java
@@ -1,0 +1,14 @@
+package com.example.spring.dto.staffcall.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class StaffCallCancelRequest {
+
+    private Long tableId;
+    private Long cartId;
+    private String callType;
+}
+

--- a/spring/src/main/java/com/example/spring/repository/staffcall/StaffCallRepository.java
+++ b/spring/src/main/java/com/example/spring/repository/staffcall/StaffCallRepository.java
@@ -36,6 +36,14 @@ public interface StaffCallRepository extends JpaRepository<StaffCall, Long> {
             @Param("offset") int offset
     );
 
+    @Query(value = """
+            SELECT COUNT(*)
+            FROM staff_call sc
+            WHERE sc.booth_id = :boothId
+            AND sc.status IN ('PENDING', 'ACCEPTED')
+            """, nativeQuery = true)
+    long countActiveCallsForBooth(@Param("boothId") Long boothId);
+
     long countByTableIdAndCartIdAndCallTypeAndStatus(
             Long tableId,
             Long cartId,

--- a/spring/src/main/java/com/example/spring/service/staffcall/StaffCallQueryService.java
+++ b/spring/src/main/java/com/example/spring/service/staffcall/StaffCallQueryService.java
@@ -23,6 +23,7 @@ public class StaffCallQueryService {
         int safeLimit = Math.min(Math.max(limit, 1), 200);
         int safeOffset = Math.max(offset, 0);
 
+        long total = staffCallRepository.countActiveCallsForBooth(boothId);
         List<StaffCall> page = staffCallRepository.findActiveCallsForBooth(boothId, safeLimit + 1, safeOffset);
         boolean hasMore = page.size() > safeLimit;
         List<StaffCall> slice = hasMore ? page.subList(0, safeLimit) : page;
@@ -35,6 +36,7 @@ public class StaffCallQueryService {
         body.put("message", "ok");
         body.put("data", items);
         body.put("has_more", hasMore);
+        body.put("total", total);
         return body;
     }
 }

--- a/spring/src/main/java/com/example/spring/service/staffcall/StaffCallService.java
+++ b/spring/src/main/java/com/example/spring/service/staffcall/StaffCallService.java
@@ -16,6 +16,7 @@ import com.example.spring.repository.cart.CartEntityRepository;
 import com.example.spring.repository.staffcall.StaffCallRepository;
 import com.example.spring.repository.table.BoothTableRepository;
 import com.example.spring.repository.table.TableUsageEntityRepository;
+import com.example.spring.websocket.CustomerStaffCallWebSocketHandler;
 import com.example.spring.websocket.StaffCallWebSocketHandler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -47,6 +48,10 @@ public class StaffCallService {
     @Lazy
     @Autowired
     private StaffCallWebSocketHandler staffCallWebSocketHandler;
+
+    @Lazy
+    @Autowired
+    private CustomerStaffCallWebSocketHandler customerStaffCallWebSocketHandler;
 
     @Transactional
     public StaffCallAcceptResponse accept(Long boothId, String accessToken, StaffCallAcceptRequest req) {
@@ -80,6 +85,7 @@ public class StaffCallService {
         try {
             staffCallWebSocketHandler.broadcastSnapshot(boothId,
                     staffCallQueryService.listForBooth(boothId, 50, 0));
+            customerStaffCallWebSocketHandler.broadcastStatus(sc);
         } catch (Exception e) {
             log.error("[staffcall accept] 스냅샷 조회/WS 푸시 실패 — 수락은 반영됨 boothId={}", boothId, e);
         }
@@ -123,6 +129,7 @@ public class StaffCallService {
         try {
             staffCallWebSocketHandler.broadcastSnapshot(boothId,
                     staffCallQueryService.listForBooth(boothId, 50, 0));
+            customerStaffCallWebSocketHandler.broadcastStatus(sc);
         } catch (Exception e) {
             log.error("[staffcall cancelAccept] 스냅샷 조회/WS 푸시 실패 — 취소는 반영됨 boothId={}", boothId, e);
         }
@@ -176,10 +183,13 @@ public class StaffCallService {
 
         staffCallRepository.save(sc);
 
+        String subscribeToken = customerStaffCallWebSocketHandler.issueSubscribeToken(sc.getId());
+
         publishRedis(sc, "staff_call_created");
         try {
             staffCallWebSocketHandler.broadcastSnapshot(boothId,
                     staffCallQueryService.listForBooth(boothId, 50, 0));
+            customerStaffCallWebSocketHandler.broadcastStatus(sc);
         } catch (Exception e) {
             // 호출 생성/수락은 저장 트랜잭션에 포함된 비즈니스 결과이므로
             // WS 스냅샷 실패가 전체 요청을 500으로 만들지 않도록 예외를 삼킨다.
@@ -189,6 +199,7 @@ public class StaffCallService {
         Map<String, Object> out = new HashMap<>();
         out.put("message", "직원 호출이 등록되었습니다.");
         out.put("data", StaffCallItemResponse.from(sc));
+        out.put("subscribe_token", subscribeToken);
         return out;
     }
 

--- a/spring/src/main/java/com/example/spring/service/staffcall/StaffCallService.java
+++ b/spring/src/main/java/com/example/spring/service/staffcall/StaffCallService.java
@@ -8,6 +8,7 @@ import com.example.spring.domain.table.BoothTable;
 import com.example.spring.domain.table.TableUsageEntity;
 import com.example.spring.dto.redis.StaffCallRedisMessageDto;
 import com.example.spring.dto.staffcall.request.StaffCallAcceptRequest;
+import com.example.spring.dto.staffcall.request.StaffCallCancelRequest;
 import com.example.spring.dto.staffcall.request.StaffCallEmitRequest;
 import com.example.spring.dto.staffcall.response.StaffCallAcceptResponse;
 import com.example.spring.dto.staffcall.response.StaffCallItemResponse;
@@ -62,6 +63,9 @@ public class StaffCallService {
         }
 
         if (sc.getStatus() != StaffCallStatus.PENDING) {
+            if (sc.getStatus() == StaffCallStatus.ACCEPTED) {
+                throw new StaffCallConflictException("이미 수락된 요청입니다.");
+            }
             throw new StaffCallConflictException("이미 처리된 요청입니다.");
         }
 
@@ -88,6 +92,45 @@ public class StaffCallService {
                 .acceptedAt(sc.getAcceptedAt())
                 .acceptedBy(sc.getAcceptedBy())
                 .build();
+    }
+
+    @Transactional
+    public Map<String, Object> cancelAccept(Long boothId, String accessToken, StaffCallCancelRequest req) {
+        if (req.getTableId() == null || req.getCartId() == null || req.getCallType() == null) {
+            throw new IllegalArgumentException("table_id, cart_id, call_type은 필수입니다.");
+        }
+
+        StaffCall sc = staffCallRepository
+                .findByTableCartCallTypeForUpdate(req.getTableId(), req.getCartId(), req.getCallType())
+                .orElseThrow(() -> new IllegalArgumentException("해당 호출을 찾을 수 없습니다."));
+
+        if (!boothId.equals(sc.getBoothId())) {
+            throw new IllegalArgumentException("부스 정보가 일치하지 않습니다.");
+        }
+
+        if (sc.getStatus() != StaffCallStatus.ACCEPTED) {
+            throw new StaffCallConflictException("수락된 호출만 취소할 수 있습니다.");
+        }
+
+        String actor = jwtUtil.getUsernameFromToken(accessToken);
+        if (actor != null && !actor.isBlank() && sc.getAcceptedBy() != null && !sc.getAcceptedBy().equals(actor)) {
+            throw new StaffCallConflictException("다른 사용자가 수락한 호출은 취소할 수 없습니다.");
+        }
+
+        sc.unaccept();
+
+        publishRedis(sc, "staff_call_unaccepted");
+        try {
+            staffCallWebSocketHandler.broadcastSnapshot(boothId,
+                    staffCallQueryService.listForBooth(boothId, 50, 0));
+        } catch (Exception e) {
+            log.error("[staffcall cancelAccept] 스냅샷 조회/WS 푸시 실패 — 취소는 반영됨 boothId={}", boothId, e);
+        }
+
+        Map<String, Object> out = new HashMap<>();
+        out.put("message", "호출 수락을 취소했습니다.");
+        out.put("data", StaffCallItemResponse.from(sc));
+        return out;
     }
 
     @Transactional

--- a/spring/src/main/java/com/example/spring/websocket/CustomerStaffCallWebSocketHandler.java
+++ b/spring/src/main/java/com/example/spring/websocket/CustomerStaffCallWebSocketHandler.java
@@ -1,0 +1,162 @@
+package com.example.spring.websocket;
+
+import com.example.spring.domain.staffcall.StaffCall;
+import com.example.spring.repository.staffcall.StaffCallRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.io.IOException;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 커스터머(태블릿/웹)에서 특정 staff_call_id의 상태 변화를 구독하기 위한 WS.
+ *
+ * - 인증(쿠키/JWT) 없이 연결 가능해야 하므로, staff_call_id + subscribe_token으로 구독을 허용한다.
+ * - 이후 ACCEPTED/PENDING 등 상태 변화가 발생하면 해당 staff_call_id 구독자에게 이벤트를 푸시한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomerStaffCallWebSocketHandler extends TextWebSocketHandler {
+
+    private static final String REDIS_SUBSCRIBE_TOKEN_KEY_PREFIX = "spring:staffcall:subscribe:";
+    private static final Duration SUBSCRIBE_TOKEN_TTL = Duration.ofMinutes(30);
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private final StaffCallRepository staffCallRepository;
+    private final ObjectMapper objectMapper;
+    private final StringRedisTemplate redisTemplate;
+
+    private final Map<Long, Set<WebSocketSession>> staffCallSessions = new ConcurrentHashMap<>();
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) {
+        log.info("[customer staffcall ws] 연결 session={}", session.getId());
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
+        for (Set<WebSocketSession> set : staffCallSessions.values()) {
+            set.remove(session);
+        }
+    }
+
+    @Override
+    protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+        JsonNode root = objectMapper.readTree(message.getPayload());
+        String type = root.path("type").asText("");
+        if (!"SUBSCRIBE".equalsIgnoreCase(type)) {
+            return;
+        }
+
+        long staffCallId = root.path("staff_call_id").asLong(0);
+        String token = root.path("subscribe_token").asText("");
+        if (staffCallId <= 0) {
+            session.sendMessage(new TextMessage(objectMapper.writeValueAsString(Map.of(
+                    "type", "ERROR",
+                    "message", "staff_call_id가 필요합니다."
+            ))));
+            return;
+        }
+        if (token == null || token.isBlank()) {
+            session.sendMessage(new TextMessage(objectMapper.writeValueAsString(Map.of(
+                    "type", "ERROR",
+                    "message", "subscribe_token이 필요합니다."
+            ))));
+            return;
+        }
+
+        StaffCall sc = staffCallRepository.findById(staffCallId).orElse(null);
+        if (sc == null) {
+            session.sendMessage(new TextMessage(objectMapper.writeValueAsString(Map.of(
+                    "type", "ERROR",
+                    "message", "구독할 수 없는 staff_call_id 입니다."
+            ))));
+            return;
+        }
+
+        String expected = getSubscribeToken(staffCallId);
+        if (expected == null || !expected.equals(token)) {
+            session.sendMessage(new TextMessage(objectMapper.writeValueAsString(Map.of(
+                    "type", "ERROR",
+                    "message", "유효하지 않은 subscribe_token 입니다."
+            ))));
+            return;
+        }
+
+        staffCallSessions.computeIfAbsent(staffCallId, k -> ConcurrentHashMap.newKeySet()).add(session);
+
+        session.sendMessage(new TextMessage(objectMapper.writeValueAsString(Map.of(
+                "type", "SUBSCRIBED",
+                "staff_call_id", staffCallId
+        ))));
+
+        // 구독 직후 현재 상태를 즉시 내려준다 (커스터머는 이걸 보고 화면 전환 판단 가능)
+        session.sendMessage(new TextMessage(objectMapper.writeValueAsString(statusEvent(sc))));
+    }
+
+    public void broadcastStatus(StaffCall sc) {
+        Set<WebSocketSession> sessions = staffCallSessions.get(sc.getId());
+        if (sessions == null || sessions.isEmpty()) return;
+
+        try {
+            String json = objectMapper.writeValueAsString(statusEvent(sc));
+            TextMessage tm = new TextMessage(json);
+            for (WebSocketSession s : sessions) {
+                if (s.isOpen()) {
+                    try {
+                        s.sendMessage(tm);
+                    } catch (IOException e) {
+                        log.warn("[customer staffcall ws] 전송 실패 session={}", s.getId(), e);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.error("[customer staffcall ws] broadcast 실패 staffCallId={}", sc.getId(), e);
+        }
+    }
+
+    private Map<String, Object> statusEvent(StaffCall sc) {
+        Map<String, Object> out = new HashMap<>();
+        out.put("type", "STAFF_CALL_STATUS");
+        out.put("staff_call_id", sc.getId());
+        out.put("status", sc.getStatus() != null ? sc.getStatus().name() : null);
+        out.put("accepted_by", sc.getAcceptedBy());
+        out.put("accepted_at", sc.getAcceptedAt());
+        out.put("table_id", sc.getTableId());
+        out.put("cart_id", sc.getCartId());
+        out.put("call_type", sc.getCallType());
+        return out;
+    }
+
+    /**
+     * staff_call_id 기반 커스터머 구독 토큰을 발급한다.
+     * (DB 인증 없이 구독할 수 있도록, 서버가 알고 있는 일회성/단기 토큰을 사용)
+     */
+    public String issueSubscribeToken(Long staffCallId) {
+        byte[] bytes = new byte[24];
+        SECURE_RANDOM.nextBytes(bytes);
+        String token = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+        redisTemplate.opsForValue().set(REDIS_SUBSCRIBE_TOKEN_KEY_PREFIX + staffCallId, token, SUBSCRIBE_TOKEN_TTL);
+        return token;
+    }
+
+    private String getSubscribeToken(Long staffCallId) {
+        return redisTemplate.opsForValue().get(REDIS_SUBSCRIBE_TOKEN_KEY_PREFIX + staffCallId);
+    }
+}
+

--- a/spring/src/main/java/com/example/spring/websocket/StaffCallWebSocketHandler.java
+++ b/spring/src/main/java/com/example/spring/websocket/StaffCallWebSocketHandler.java
@@ -80,6 +80,7 @@ public class StaffCallWebSocketHandler extends TextWebSocketHandler {
         out.put("message", snapshot.get("message"));
         out.put("data", snapshot.get("data"));
         out.put("has_more", snapshot.get("has_more"));
+        out.put("total", snapshot.get("total"));
 
         session.sendMessage(new TextMessage(objectMapper.writeValueAsString(out)));
     }
@@ -95,6 +96,7 @@ public class StaffCallWebSocketHandler extends TextWebSocketHandler {
             out.put("message", snapshot.get("message"));
             out.put("data", snapshot.get("data"));
             out.put("has_more", snapshot.get("has_more"));
+            out.put("total", snapshot.get("total"));
             String json = objectMapper.writeValueAsString(out);
             TextMessage tm = new TextMessage(json);
             for (WebSocketSession s : sessions) {


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->
staffcall 기능 고도화: 수락 취소(unaccept) API 추가 (POST /api/v3/spring/server/staffcall/cancel)
staffcall 목록 응답에 total(전체 개수) 포함 + WS 스냅샷에도 동일 필드 포함
수락 경합 시 실패 응답 메시지 구체화: “이미 수락된 요청입니다.”
커스터머 대기 UX 지원:
커스터머 전용 WS /ws/customer/staffcall 추가(연결은 인증 없이)


## 📍 PR Point

<!-- 나 이 부분 찢었다~! -->

- 동시 수락 경쟁 제어: DB 락 + 상태 체크로 “첫 1명만 수락” 보장, 나머지는 409로 명확한 메시지 제공
- 커스터머는 인증 없이 대기: subscribe_token 기반 구독으로 WS를 안전하게 공개(쿠키/JWT 없이도 승인 순간 화면 전환 가능)
- 서버 화면 UX 개선: total로 배지/페이지네이션 정확도 향상, WS 스냅샷과 HTTP 응답 스키마 일치


## 📢 Notices

 <!-- 공용으로 사용하는(Extension) 부분에 대한 설명 -->

- /server/staffcall/request 응답에 subscribe_token이 추가되었습니다(커스터머 WS 구독에 필요).
- 새 WS 경로 /ws/customer/staffcall 추가: SUBSCRIBE(staff_call_id, subscribe_token) 프로토콜 사용.
- total 필드가 staffcall HTTP/WS 응답에 추가되었습니다.

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #210 
<!-- - ex) #3 -->