### PR TITLE
🐛 [Fix] - Cart pending 복귀 로직 및 WS 이벤트 추가

### DIFF
--- a/django/cart/serializers.py
+++ b/django/cart/serializers.py
@@ -51,3 +51,7 @@ class DeleteItemSerializer(serializers.Serializer):
 
 class PaymentInfoSerializer(serializers.Serializer):
     table_usage_id = serializers.IntegerField()
+    
+
+class PaymentCancelSerializer(serializers.Serializer):
+    table_usage_id = serializers.IntegerField()

--- a/django/cart/services.py
+++ b/django/cart/services.py
@@ -89,11 +89,14 @@ def _ensure_table_usage_alive(table_usage: TableUsage):
         raise CartError("이미 종료된 세션입니다.", "TABLE_USAGE_ENDED", status_code=410)
 
 
-def _restore_if_pending_expired(cart: Cart):
-    if cart.is_pending_expired():
-        cart.status = Cart.Status.ACTIVE
-        cart.pending_expires_at = None
-        cart.save(update_fields=["status", "pending_expires_at"])
+def _restore_if_pending_expired(cart: Cart) -> bool:
+    if not cart.is_pending_expired():
+        return False
+
+    cart.status = Cart.Status.ACTIVE
+    cart.pending_expires_at = None
+    cart.save(update_fields=["status", "pending_expires_at"])
+    return True
 
 
 def _sync_item_prices_to_latest(cart: Cart) -> None:
@@ -242,7 +245,22 @@ def get_or_create_cart_by_table_usage(table_usage_id: int) -> Cart:
     _ensure_table_usage_alive(table_usage)
 
     cart, _ = Cart.objects.select_for_update().get_or_create(table_usage=table_usage)
-    _restore_if_pending_expired(cart)
+
+    restored = _restore_if_pending_expired(cart)
+
+    if restored:
+        final_table_usage_id = cart.table_usage_id
+
+        from .services_ws import broadcast_cart_event
+
+        transaction.on_commit(
+            lambda: broadcast_cart_event(
+                table_usage_id=final_table_usage_id,
+                event_type="CART_PENDING_EXPIRED",
+                message="결제 대기 시간이 만료되어 장바구니가 다시 활성화되었습니다.",
+            )
+        )
+
     return cart
 
 @transaction.atomic
@@ -512,6 +530,35 @@ def enter_payment_info(*, table_usage_id: int):
     }
 
     return cart, payment
+
+@transaction.atomic
+def cancel_payment_and_restore_cart(*, table_usage_id: int) -> Cart:
+    cart = get_or_create_cart_by_table_usage(table_usage_id)
+
+    if cart.status != Cart.Status.PENDING:
+        raise CartError(
+            "현재 결제 취소가 가능한 상태가 아닙니다.",
+            "CART_NOT_PENDING",
+            status_code=409,
+        )
+
+    cart.status = Cart.Status.ACTIVE
+    cart.pending_expires_at = None
+    cart.save(update_fields=["status", "pending_expires_at"])
+
+    final_table_usage_id = cart.table_usage_id
+
+    from .services_ws import broadcast_cart_event
+
+    transaction.on_commit(
+        lambda: broadcast_cart_event(
+            table_usage_id=final_table_usage_id,
+            event_type="CART_PAYMENT_CANCELLED",
+            message="결제가 취소되어 장바구니가 다시 활성화되었습니다.",
+        )
+    )
+
+    return cart
 
 def _calc_discount(subtotal: int, discount_type: str, discount_value) -> int:
     # 결제 확정 시점(Order 생성)에 '할인액/결제액'을 확정해야 해서 계산 필요

--- a/django/cart/urls.py
+++ b/django/cart/urls.py
@@ -7,4 +7,5 @@ urlpatterns = [
     path("menu/", CartUpdateQuantityAPIView.as_view(), name="cart-update-quantity"),
     path("menu/delete/", CartDeleteItemAPIView.as_view(), name="cart-delete-item"),
     path("payment-info/", CartPaymentInfoAPIView.as_view(), name="cart-payment-info"),
+    path("payment-cancel/", CartPaymentCancelAPIView.as_view(), name="cart-payment-cancel"),
 ]

--- a/django/cart/views.py
+++ b/django/cart/views.py
@@ -279,3 +279,35 @@ class CartPaymentInfoAPIView(APIView):
             },
             status=200,
         )
+        
+class CartPaymentCancelAPIView(APIView):
+    """
+    POST /api/v3/django/cart/payment-cancel/
+    """
+
+    def post(self, request):
+        serializer = PaymentCancelSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        try:
+            cart = cancel_payment_and_restore_cart(
+                table_usage_id=serializer.validated_data["table_usage_id"]
+            )
+        except CartError as e:
+            return error_response(e)
+
+        return Response(
+            {
+                "message": "결제가 취소되어 장바구니가 다시 활성화되었습니다.",
+                "data": {
+                    "cart": {
+                        "id": cart.id,
+                        "table_usage_id": cart.table_usage_id,
+                        "status": cart.status,
+                        "pending_expires_at": cart.pending_expires_at,
+                        "round": cart.round,
+                    }
+                },
+            },
+            status=200,
+        )


### PR DESCRIPTION
## 🔍 What is the PR?

- 결제 확인 단계(pending)에서 장바구니를 다시 active로 복귀시키는 로직 추가
- payment-cancel API 추가 (POST /api/v3/django/cart/payment-cancel/)
- pending → active 전환 시 WebSocket 이벤트 전송
-transaction.on_commit() 기반으로 WS 전송 시점 안정화
- pending 상태에서만 취소 가능하도록 상태 검증 로직 추가


## 📍 PR Point

- pending 상태 복귀 흐름을 명시적으로 분리해서 상태 전환 구조 개선
- WS 이벤트를 commit 이후에 전송하도록 처리해서 데이터 정합성 보장

## 📢 Notices

- payment-cancel은 결제 취소(order 도메인)가 아니라 pending 상태 해제(cart 도메인) 목적의 API임. 
- 프론트에서는 결제 확인 화면 이탈 시 해당 API 호출 필요
- WS 이벤트: CART_PAYMENT_CANCELLED 수신 후 UI를 active 상태로 복귀 처리 필요

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

#218 