### PR TITLE
✨🐛 [feat-fix] - WS 이벤트 분리 및 결제 확정 시점 API 생성

### DIFF
--- a/django/cart/serializers.py
+++ b/django/cart/serializers.py
@@ -55,3 +55,10 @@ class PaymentInfoSerializer(serializers.Serializer):
 
 class PaymentCancelSerializer(serializers.Serializer):
     table_usage_id = serializers.IntegerField()
+    
+class PaymentConfirmSerializer(serializers.Serializer):
+    table_usage_id = serializers.IntegerField()
+
+
+class CartResetSerializer(serializers.Serializer):
+    table_usage_id = serializers.IntegerField()

--- a/django/cart/services.py
+++ b/django/cart/services.py
@@ -573,28 +573,9 @@ def _calc_discount(subtotal: int, discount_type: str, discount_value) -> int:
     return max(0, min(subtotal, amt))
 
 
-@transaction.atomic
-def finalize_payment_and_rotate_cart(*, table_usage_id: int) -> Cart:
-
-    # 운영자 입금 확인(결제 확정) 시점에 호출되는 '최종 확정 처리' 훅
-    # 여기서 주문 생성/재고 차감/매출 반영/쿠폰 used 처리까지 한 트랜잭션으로 묶음
-    
-    cart = get_or_create_cart_by_table_usage(table_usage_id)
-
-    if cart.status != Cart.Status.PENDING:
-        _validate_required_fee_for_first_round(cart)
-        raise CartError(
-            "결제 진행 중인(PENDING) 상태에서만 확정할 수 있습니다.",
-            "CART_NOT_PENDING",
-            status_code=409,
-        )
-
-    # 1) 최신 가격 동기화 + subtotal 확정
+def _finalize_payment_core(cart: Cart):
     subtotal = recalc_cart_price(cart)
 
-    # 2) 재고 재검증 + (동시성) 관련 메뉴 row 잠금
-    #    결제 확정 직전에 재고가 바뀌었을 수 있으니 마지막 가드 필요
-    #    그리고 이후 stock 차감이 들어가므로 select_for_update로 잠그려고 함 !!!!!!!!!!
     cart_items = list(
         cart.items.select_related("menu", "setmenu").prefetch_related("setmenu__items__menu")
     )
@@ -629,7 +610,6 @@ def finalize_payment_and_rotate_cart(*, table_usage_id: int) -> Cart:
         for comp in comps:
             set_components.setdefault(comp.set_menu_id, []).append(comp)
 
-        # 세트 구성품 메뉴도 locked_menus에 넣어두기
         comp_menu_ids = list({comp.menu_id for comp in comps})
         extra_menus = Menu.objects.select_for_update().filter(id__in=comp_menu_ids)
         for m in extra_menus:
@@ -639,14 +619,12 @@ def finalize_payment_and_rotate_cart(*, table_usage_id: int) -> Cart:
         menu = locked_menus[menu_id]
         _validate_menu_stock(menu, want_qty)
 
-    # 3) 쿠폰(예약) 확인 + 결제액 확정 + used_at 최종 처리
-    #    apply/cancel은 예약만. 확정(주문 생성) 시점에만 used_at을 찍어야 함.
     discount_total = 0
-    applied_code = None
     applied_coupon = None
 
     try:
-        from coupon.models import CartCouponApply  # 순환 import 최소화: 함수 내부 import
+        from coupon.models import CartCouponApply
+
         applied = (
             CartCouponApply.objects.select_for_update()
             .filter(cart=cart, round=cart.round)
@@ -657,7 +635,6 @@ def finalize_payment_and_rotate_cart(*, table_usage_id: int) -> Cart:
             applied_code = applied.coupon_code
             applied_coupon = applied_code.coupon
 
-            # 이미 used면(다른 주문에서 확정된 코드) 충돌 처리
             if applied_code.used_at is not None:
                 raise CartError(
                     "이미 사용된 쿠폰 코드입니다.",
@@ -665,9 +642,12 @@ def finalize_payment_and_rotate_cart(*, table_usage_id: int) -> Cart:
                     status_code=409,
                 )
 
-            discount_total = _calc_discount(subtotal, applied_coupon.discount_type, applied_coupon.discount_value)
+            discount_total = _calc_discount(
+                subtotal,
+                applied_coupon.discount_type,
+                applied_coupon.discount_value,
+            )
 
-            # 결제 확정 시점에만 used_at 기록
             applied_code.used_at = timezone.now()
             applied_code.save(update_fields=["used_at"])
     except CartError:
@@ -677,18 +657,16 @@ def finalize_payment_and_rotate_cart(*, table_usage_id: int) -> Cart:
 
     order_price = subtotal - discount_total
 
-    # 4) Order 생성 + OrderItem 생성
     order = Order.objects.create(
         table_usage=cart.table_usage,
         cart=cart,
         order_price=order_price,
         original_price=subtotal,
         total_discount=discount_total,
-        coupon_id=(applied_coupon.id if applied_coupon else None),  # 모델 help_text는 "Spring 관리"지만 우선 로깅용으로라도 박아두는 게 유용
+        coupon_id=(applied_coupon.id if applied_coupon else None),
         order_status="PAID",
     )
 
-    # OrderItem 생성 + 재고 차감까지 같이 처리
     for it in cart_items:
         if it.menu_id:
             if it.menu.category == Menu.Category.FEE:
@@ -743,13 +721,52 @@ def finalize_payment_and_rotate_cart(*, table_usage_id: int) -> Cart:
                 child_menu.stock = F("stock") - child_qty
                 child_menu.save(update_fields=["stock"])
 
-    # 5) Booth.total_revenues 반영
     booth = cart.table_usage.table.booth
     Booth.objects.filter(pk=booth.pk).update(total_revenues=F("total_revenues") + order_price)
 
-    # 6) Cart 상태/라운드/아이템 정리 (재사용 정책)
+    return order
+
+@transaction.atomic
+def confirm_payment_and_mark_ordered(*, table_usage_id: int) -> Cart:
+    cart = get_or_create_cart_by_table_usage(table_usage_id)
+
+    if cart.status != Cart.Status.PENDING:
+        raise CartError(
+            "결제 진행 중인(PENDING) 상태에서만 확정할 수 있습니다.",
+            "CART_NOT_PENDING",
+            status_code=409,
+        )
+
+    _finalize_payment_core(cart)
+
     cart.status = Cart.Status.ORDERED
-    cart.save(update_fields=["status"])
+    cart.pending_expires_at = None
+    cart.save(update_fields=["status", "pending_expires_at"])
+
+    final_table_usage_id = cart.table_usage_id
+
+    from .services_ws import broadcast_cart_event
+
+    transaction.on_commit(
+        lambda: broadcast_cart_event(
+            table_usage_id=final_table_usage_id,
+            event_type="CART_PAYMENT_CONFIRMED",
+            message="결제가 확인되어 주문이 완료되었습니다.",
+        )
+    )
+
+    return cart
+
+@transaction.atomic
+def reset_ordered_cart(*, table_usage_id: int) -> Cart:
+    cart = get_or_create_cart_by_table_usage(table_usage_id)
+
+    if cart.status != Cart.Status.ORDERED:
+        raise CartError(
+            "주문 완료(ORDERED) 상태에서만 장바구니를 초기화할 수 있습니다.",
+            "CART_NOT_ORDERED",
+            status_code=409,
+        )
 
     cart.items.all().delete()
 
@@ -757,11 +774,11 @@ def finalize_payment_and_rotate_cart(*, table_usage_id: int) -> Cart:
     cart.status = Cart.Status.ACTIVE
     cart.pending_expires_at = None
     cart.save(update_fields=["round", "status", "pending_expires_at"])
-    
+
     final_table_usage_id = cart.table_usage_id
 
     from .services_ws import broadcast_cart_event
-    
+
     transaction.on_commit(
         lambda: broadcast_cart_event(
             table_usage_id=final_table_usage_id,

--- a/django/cart/urls.py
+++ b/django/cart/urls.py
@@ -8,4 +8,6 @@ urlpatterns = [
     path("menu/delete/", CartDeleteItemAPIView.as_view(), name="cart-delete-item"),
     path("payment-info/", CartPaymentInfoAPIView.as_view(), name="cart-payment-info"),
     path("payment-cancel/", CartPaymentCancelAPIView.as_view(), name="cart-payment-cancel"),
+    path("payment-confirm/", CartPaymentConfirmAPIView.as_view()),
+    path("reset/", CartResetAPIView.as_view()),
 ]

--- a/django/cart/views.py
+++ b/django/cart/views.py
@@ -311,3 +311,70 @@ class CartPaymentCancelAPIView(APIView):
             },
             status=200,
         )
+        
+class CartPaymentConfirmAPIView(APIView):
+    """
+    POST /api/v3/django/cart/payment-confirm/
+    운영진이 결제 확인 슬라이드 완료 시 호출
+    """
+
+    def post(self, request):
+        serializer = PaymentConfirmSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        try:
+            cart = confirm_payment_and_mark_ordered(
+                table_usage_id=serializer.validated_data["table_usage_id"]
+            )
+        except CartError as e:
+            return error_response(e)
+
+        return Response(
+            {
+                "message": "결제가 확인되어 주문이 완료되었습니다.",
+                "data": {
+                    "cart": {
+                        "id": cart.id,
+                        "table_usage_id": cart.table_usage_id,
+                        "status": cart.status,
+                        "pending_expires_at": cart.pending_expires_at,
+                        "round": cart.round,
+                    }
+                },
+            },
+            status=200,
+        )
+
+
+class CartResetAPIView(APIView):
+    """
+    POST /api/v3/django/cart/reset/
+    주문 완료 화면 처리 후 cart를 새 round로 초기화
+    """
+
+    def post(self, request):
+        serializer = CartResetSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        try:
+            cart = reset_ordered_cart(
+                table_usage_id=serializer.validated_data["table_usage_id"]
+            )
+        except CartError as e:
+            return error_response(e)
+
+        return Response(
+            {
+                "message": "장바구니가 초기화되었습니다.",
+                "data": {
+                    "cart": {
+                        "id": cart.id,
+                        "table_usage_id": cart.table_usage_id,
+                        "status": cart.status,
+                        "pending_expires_at": cart.pending_expires_at,
+                        "round": cart.round,
+                    }
+                },
+            },
+            status=200,
+        )


### PR DESCRIPTION
## 🔍 What is the PR?

- cart 결제 확정 흐름을 `pending -> ordered -> active`로 분리
- 운영진 결제 확인 시 `CART_PAYMENT_CONFIRMED` WS 이벤트를 추가
- 주문 완료 후 새 round 장바구니 초기화를 위한 reset API를 추가
- 관련 serializer / service / view / url 개발 및 WS 명세 흐름 정리


## 📍 PR Point

기존에는 결제 확인 후 바로 `CART_RESET`만 내려가서 손님 프론트가 주문 완료 시점을 포착하기 어려웠는데, 이를 `CART_PAYMENT_CONFIRMED` 이벤트로 분리해 주문 완료 UI를 안정적으로 띄울 수 있도록 개선함.

## 📢 Notices

- 손님 프론트는 `CART_PAYMENT_CONFIRMED` 수신 시 주문 완료 화면을 약 2초간 표시한 뒤 `POST /api/v3/django/cart/reset/`를 호출해야 함.
- `ordered` 상태는 장시간 유지되는 상태가 아니라 주문 완료 화면 표시를 위한 중간 상태로 사용됨.

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

#220 