### PR TITLE
🐛 [Fix] - 장바구니 500 error 해결

### DIFF
--- a/django/cart/services.py
+++ b/django/cart/services.py
@@ -107,7 +107,7 @@ def _sync_item_prices_to_latest(cart: Cart) -> None:
         SetMenu.objects.filter(pk=OuterRef("setmenu_id")).values("price")[:1]
     )
 
-    qs = CartItem.objects.select_for_update().filter(cart=cart)
+    qs = CartItem.objects.filter(cart=cart)
     qs.update(
         price_at_cart=Case(
             When(menu__isnull=False, then=menu_price_subquery),

--- a/django/cart/services_ws.py
+++ b/django/cart/services_ws.py
@@ -4,7 +4,13 @@ from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
 
 from table.models import TableUsage
-from cart.services import *
+from cart.services import (
+    get_or_create_cart_by_table_usage,
+    recalc_cart_price,
+    _calc_discount,
+    _is_fee_booth,         
+    _can_add_fee_in_this_round
+)
 
 logger = logging.getLogger(__name__)
 

--- a/django/cart/views.py
+++ b/django/cart/views.py
@@ -5,7 +5,20 @@ from rest_framework.response import Response
 from table.models import TableUsage
 from .models import *
 from .serializers import *
-from .services import *
+from .services import (
+    CartError,
+    add_to_cart,
+    get_or_create_cart_by_table_usage,
+    recalc_cart_price,
+    update_item_quantity,
+    delete_item,
+    enter_payment_info,
+    cancel_payment_and_restore_cart,
+    confirm_payment_and_mark_ordered,
+    reset_ordered_cart,
+    _is_fee_booth,
+    _can_add_fee_in_this_round 
+)
 from .services_ws import *
 
 


### PR DESCRIPTION
## 🔍 What is the PR?

- Cart API 500 Internal Server Error 해결
- 내부 함수(Internal Functions) 참조 오류 해결
- 임포트 구조 최적화

## 📍 PR Point

더바(_) 컨벤션을 유지하면서도 명시적 임포트를 통해 서비스 레이어의 로직을 뷰와 웹소켓 레이어에서 안전하게 사용할 수 있도록 구성

## 📢 Notices

- cart/services.py의 _sync_item_prices_to_latest 로직이 변경
- 이제 장바구니 관련 내부 정책 함수(_is_fee_booth 등)를 가져올 때는 반드시 명시적으로 임포트 리스트에 추가

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

- #222 