### PR TITLE
🐛 [Fix] - PK 참조 오류 해결

### DIFF
--- a/django/cart/services.py
+++ b/django/cart/services.py
@@ -282,7 +282,7 @@ def add_to_cart(*, table_usage_id: int, type: str, quantity: int, menu_id: int =
 
         menu = get_object_or_404(Menu.objects.select_for_update(), id=menu_id)
 
-        if menu.booth_id != booth.id:
+        if menu.booth_id != booth.pk:
             raise CartError(
                 "현재 부스의 메뉴만 담을 수 있습니다.",
                 "MENU_BOOTH_MISMATCH",
@@ -360,7 +360,7 @@ def add_to_cart(*, table_usage_id: int, type: str, quantity: int, menu_id: int =
 
         setmenu = get_object_or_404(SetMenu.objects.select_for_update(), id=set_menu_id)
 
-        if setmenu.booth_id != booth.id:
+        if setmenu.booth_id != booth.pk:
             raise CartError(
                 "현재 부스의 세트메뉴만 담을 수 있습니다.",
                 "SETMENU_BOOTH_MISMATCH",


### PR DESCRIPTION
## 🔍 What is the PR?

- Booth 모델 PK 구조(user 기반)와 맞지 않는 booth.id 참조 수정 -> 장바구니 추가 시 발생하던 500 에러 해결

## 📍 PR Point

부스 아이디 실제 PK 기준 비교 로직 정상화

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 - #222 
