### PR TITLE
🐛 [Fix] #225 - 직원호출 결제확인 수정

### DIFF
--- a/spring/src/main/java/com/example/spring/controller/staffcall/StaffCallController.java
+++ b/spring/src/main/java/com/example/spring/controller/staffcall/StaffCallController.java
@@ -2,6 +2,7 @@ package com.example.spring.controller.staffcall;
 
 import com.example.spring.dto.staffcall.request.StaffCallAcceptRequest;
 import com.example.spring.dto.staffcall.request.StaffCallCancelRequest;
+import com.example.spring.dto.staffcall.request.StaffCallCompleteRequest;
 import com.example.spring.dto.staffcall.request.StaffCallEmitRequest;
 import com.example.spring.dto.staffcall.request.StaffCallListRequest;
 import com.example.spring.dto.staffcall.response.StaffCallAcceptResponse;
@@ -73,6 +74,24 @@ public class StaffCallController {
                     "message", "호출을 수락했습니다.",
                     "data", data
             ));
+        } catch (StaffCallConflictException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("message", e.getMessage()));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("message", e.getMessage()));
+        }
+    }
+
+    /**
+     * POST /api/v3/spring/server/staffcall/complete
+     * 수락된 호출을 완료 처리 → Redis로 Django에 결제확인 이벤트 발행
+     */
+    @PostMapping("/staffcall/complete")
+    public ResponseEntity<Map<String, Object>> complete(
+            @RequestBody StaffCallCompleteRequest body,
+            HttpServletRequest request) {
+        try {
+            Long boothId = (Long) request.getAttribute(ServerApiJwtFilter.ATTR_BOOTH_ID);
+            return ResponseEntity.ok(staffCallService.complete(boothId, body));
         } catch (StaffCallConflictException e) {
             return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("message", e.getMessage()));
         } catch (IllegalArgumentException e) {

--- a/spring/src/main/java/com/example/spring/domain/cart/CartEntity.java
+++ b/spring/src/main/java/com/example/spring/domain/cart/CartEntity.java
@@ -19,4 +19,8 @@ public class CartEntity {
 
     @Column(name = "table_usage_id", nullable = false)
     private Long tableUsageId;
+
+    /** Django cart_cart.cart_price — 장바구니 총 금액 */
+    @Column(name = "cart_price", nullable = false)
+    private Integer cartPrice;
 }

--- a/spring/src/main/java/com/example/spring/domain/staffcall/StaffCall.java
+++ b/spring/src/main/java/com/example/spring/domain/staffcall/StaffCall.java
@@ -25,6 +25,18 @@ public class StaffCall {
     @Column(name = "cart_id", nullable = false)
     private Long cartId;
 
+    /** Django cart.table_usage_id — 결제확인 시 Django에 전달하기 위한 비정규화 */
+    @Column(name = "table_usage_id")
+    private Long tableUsageId;
+
+    /** Django table_table.table_num — 프론트 표시용 테이블 번호 */
+    @Column(name = "table_num")
+    private Integer tableNum;
+
+    /** Django cart_cart.cart_price — 결제확인 모달 금액 표시용 */
+    @Column(name = "cart_price")
+    private Integer cartPrice;
+
     /** 비즈니스 호출 종류(물, 계산서 등) */
     @Column(name = "call_type", nullable = false, length = 64)
     private String callType;
@@ -57,9 +69,13 @@ public class StaffCall {
     private Long version;
 
     @Builder
-    public StaffCall(Long boothId, Long tableId, Long cartId, String callType, StaffCallCategory category) {
+    public StaffCall(Long boothId, Long tableId, Long tableUsageId, Integer tableNum, Integer cartPrice,
+                     Long cartId, String callType, StaffCallCategory category) {
         this.boothId = boothId;
         this.tableId = tableId;
+        this.tableUsageId = tableUsageId;
+        this.tableNum = tableNum;
+        this.cartPrice = cartPrice;
         this.cartId = cartId;
         this.callType = callType;
         this.category = category;
@@ -80,5 +96,11 @@ public class StaffCall {
         this.acceptedAt = null;
         this.acceptedBy = null;
         this.updatedAt = LocalDateTime.now();
+    }
+
+    public void complete() {
+        this.status = StaffCallStatus.COMPLETED;
+        this.completedAt = LocalDateTime.now();
+        this.updatedAt = this.completedAt;
     }
 }

--- a/spring/src/main/java/com/example/spring/dto/redis/StaffCallRedisMessageDto.java
+++ b/spring/src/main/java/com/example/spring/dto/redis/StaffCallRedisMessageDto.java
@@ -30,6 +30,15 @@ public class StaffCallRedisMessageDto {
     @JsonProperty("cart_id")
     private Long cartId;
 
+    @JsonProperty("table_usage_id")
+    private Long tableUsageId;
+
+    @JsonProperty("table_num")
+    private Integer tableNum;
+
+    @JsonProperty("cart_price")
+    private Integer cartPrice;
+
     @JsonProperty("call_type")
     private String callType;
 

--- a/spring/src/main/java/com/example/spring/dto/staffcall/request/StaffCallCompleteRequest.java
+++ b/spring/src/main/java/com/example/spring/dto/staffcall/request/StaffCallCompleteRequest.java
@@ -1,0 +1,13 @@
+package com.example.spring.dto.staffcall.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class StaffCallCompleteRequest {
+
+    private Long tableId;
+    private Long cartId;
+    private String callType;
+}

--- a/spring/src/main/java/com/example/spring/dto/staffcall/response/StaffCallItemResponse.java
+++ b/spring/src/main/java/com/example/spring/dto/staffcall/response/StaffCallItemResponse.java
@@ -21,6 +21,15 @@ public class StaffCallItemResponse {
     @JsonProperty("cart_id")
     private Long cartId;
 
+    @JsonProperty("table_usage_id")
+    private Long tableUsageId;
+
+    @JsonProperty("table_num")
+    private Integer tableNum;
+
+    @JsonProperty("cart_price")
+    private Integer cartPrice;
+
     @JsonProperty("call_type")
     private String callType;
 
@@ -49,6 +58,9 @@ public class StaffCallItemResponse {
                 .staffCallId(sc.getId())
                 .tableId(sc.getTableId())
                 .cartId(sc.getCartId())
+                .tableUsageId(sc.getTableUsageId())
+                .tableNum(sc.getTableNum())
+                .cartPrice(sc.getCartPrice())
                 .callType(sc.getCallType())
                 .category(sc.getCategory() != null ? sc.getCategory().name() : null)
                 .status(sc.getStatus() != null ? sc.getStatus().name() : null)

--- a/spring/src/main/java/com/example/spring/repository/staffcall/StaffCallRepository.java
+++ b/spring/src/main/java/com/example/spring/repository/staffcall/StaffCallRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -22,7 +23,8 @@ public interface StaffCallRepository extends JpaRepository<StaffCall, Long> {
     );
 
     @Query(value = """
-            SELECT sc.id, sc.booth_id, sc.table_id, sc.cart_id, sc.call_type, sc.category,
+            SELECT sc.id, sc.booth_id, sc.table_id, sc.cart_id, sc.table_usage_id, sc.table_num, sc.cart_price,
+                   sc.call_type, sc.category,
                    sc.status, sc.created_at, sc.updated_at, sc.accepted_at, sc.accepted_by, sc.completed_at, sc.version
             FROM staff_call sc
             WHERE sc.booth_id = :boothId
@@ -49,5 +51,12 @@ public interface StaffCallRepository extends JpaRepository<StaffCall, Long> {
             Long cartId,
             String callType,
             StaffCallStatus status
+    );
+
+    long countByTableIdAndCartIdAndCallTypeAndStatusIn(
+            Long tableId,
+            Long cartId,
+            String callType,
+            Collection<StaffCallStatus> statuses
     );
 }

--- a/spring/src/main/java/com/example/spring/service/staffcall/StaffCallService.java
+++ b/spring/src/main/java/com/example/spring/service/staffcall/StaffCallService.java
@@ -9,6 +9,7 @@ import com.example.spring.domain.table.TableUsageEntity;
 import com.example.spring.dto.redis.StaffCallRedisMessageDto;
 import com.example.spring.dto.staffcall.request.StaffCallAcceptRequest;
 import com.example.spring.dto.staffcall.request.StaffCallCancelRequest;
+import com.example.spring.dto.staffcall.request.StaffCallCompleteRequest;
 import com.example.spring.dto.staffcall.request.StaffCallEmitRequest;
 import com.example.spring.dto.staffcall.response.StaffCallAcceptResponse;
 import com.example.spring.dto.staffcall.response.StaffCallItemResponse;
@@ -29,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Slf4j
@@ -141,6 +143,44 @@ public class StaffCallService {
     }
 
     @Transactional
+    public Map<String, Object> complete(Long boothId, StaffCallCompleteRequest req) {
+        if (req.getTableId() == null || req.getCartId() == null || req.getCallType() == null) {
+            throw new IllegalArgumentException("table_id, cart_id, call_type은 필수입니다.");
+        }
+
+        StaffCall sc = staffCallRepository
+                .findByTableCartCallTypeForUpdate(req.getTableId(), req.getCartId(), req.getCallType())
+                .orElseThrow(() -> new IllegalArgumentException("해당 호출을 찾을 수 없습니다."));
+
+        if (!boothId.equals(sc.getBoothId())) {
+            throw new IllegalArgumentException("부스 정보가 일치하지 않습니다.");
+        }
+
+        if (sc.getStatus() != StaffCallStatus.ACCEPTED) {
+            if (sc.getStatus() == StaffCallStatus.COMPLETED) {
+                throw new StaffCallConflictException("이미 완료된 요청입니다.");
+            }
+            throw new StaffCallConflictException("수락된 호출만 완료 처리할 수 있습니다.");
+        }
+
+        sc.complete();
+
+        publishRedis(sc, "staff_call_completed");
+        try {
+            staffCallWebSocketHandler.broadcastSnapshot(boothId,
+                    staffCallQueryService.listForBooth(boothId, 50, 0));
+            customerStaffCallWebSocketHandler.broadcastStatus(sc);
+        } catch (Exception e) {
+            log.error("[staffcall complete] 스냅샷 조회/WS 푸시 실패 — 완료는 반영됨 boothId={}", boothId, e);
+        }
+
+        Map<String, Object> out = new HashMap<>();
+        out.put("message", "호출을 완료 처리했습니다.");
+        out.put("data", StaffCallItemResponse.from(sc));
+        return out;
+    }
+
+    @Transactional
     public Map<String, Object> emit(StaffCallEmitRequest req) {
         if (req.getTableId() == null || req.getCartId() == null || req.getCallType() == null || req.getCategory() == null) {
             throw new IllegalArgumentException("table_id, cart_id, call_type, category는 필수입니다.");
@@ -167,15 +207,19 @@ public class StaffCallService {
             throw new IllegalArgumentException("비활성 테이블에서는 호출할 수 없습니다.");
         }
 
-        long pendingDup = staffCallRepository.countByTableIdAndCartIdAndCallTypeAndStatus(
-                actualTableId, req.getCartId(), req.getCallType(), StaffCallStatus.PENDING);
-        if (pendingDup > 0) {
-            throw new StaffCallConflictException("동일한 호출이 이미 대기 중입니다.");
+        long activeDup = staffCallRepository.countByTableIdAndCartIdAndCallTypeAndStatusIn(
+                actualTableId, req.getCartId(), req.getCallType(),
+                List.of(StaffCallStatus.PENDING, StaffCallStatus.ACCEPTED));
+        if (activeDup > 0) {
+            throw new StaffCallConflictException("동일한 호출이 이미 진행 중입니다.");
         }
 
         StaffCall sc = StaffCall.builder()
                 .boothId(boothId)
                 .tableId(actualTableId)
+                .tableUsageId(cart.getTableUsageId())
+                .tableNum(table.getTableNum())
+                .cartPrice(cart.getCartPrice())
                 .cartId(req.getCartId())
                 .callType(req.getCallType())
                 .category(req.getCategory())
@@ -211,6 +255,9 @@ public class StaffCallService {
                     .boothId(sc.getBoothId())
                     .tableId(sc.getTableId())
                     .cartId(sc.getCartId())
+                    .tableUsageId(sc.getTableUsageId())
+                    .tableNum(sc.getTableNum())
+                    .cartPrice(sc.getCartPrice())
                     .callType(sc.getCallType())
                     .category(sc.getCategory() != null ? sc.getCategory().name() : null)
                     .status(sc.getStatus() != null ? sc.getStatus().name() : null)


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->

Spring Boot StaffCall 수정 정리

1. 결제확인 완료(complete) 엔드포인트 추가
POST /server/staffcall/complete 엔드포인트 신규
ACCEPTED → COMPLETED 상태 전이 구현 (기존에 누락)
Redis spring:booth:{boothId}:staffcall:completed 이벤트 발행 → Django 연동용

2. WS 스냅샷에 프론트 필수 필드 추가
기존에 테이블 넘버가 아니고 테이블 아이디를 내려주던것 수정 
table_usage_id — Django payment-confirm API 호출에 필수
table_num — 프론트 "T18" 등 테이블 번호 표시용
cart_price — 결제확인 모달 금액 표시용 

3. emit() 중복 체크 강화
기존: PENDING 상태만 중복 체크 → ACCEPTED 상태 호출이 있어도 동일 요청 생성 가능했음
수정: PENDING + ACCEPTED 모두 체크

## 📢 Notices

 <!-- 공용으로 사용하는(Extension) 부분에 대한 설명 -->

장고파트 수정필요사항
listen_redis.py에서 staffcall:completed 이벤트 수신 시 confirm_payment_and_mark_ordered(table_usage_id=...) 호출하도록 수정 필요

## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #225
<!-- - ex) #3 -->