### PR TITLE
🐛 [Fix] #225 - 스부 complete상태 중복예외처리, 장고 결제확인 레디스 추가

### DIFF
--- a/django/core/management/commands/listen_redis.py
+++ b/django/core/management/commands/listen_redis.py
@@ -50,6 +50,10 @@ class Command(BaseCommand):
                 if domain == "order":
                     self._handle_order_event(booth_id, action, data, channel_layer)
 
+                # ──── StaffCall 도메인 처리 ────
+                elif domain == "staffcall":
+                    self._handle_staffcall_event(booth_id, action, data, channel_layer)
+
                 # ──── 기타 도메인 → WebSocket 브로드캐스트 ────
                 else:
                     group_name = f"booth_{booth_id}.{domain}"
@@ -68,6 +72,35 @@ class Command(BaseCommand):
                 self.stderr.write(self.style.ERROR(f"메시지 처리 실패: {e}"))
                 import traceback
                 self.stderr.write(traceback.format_exc())
+
+    def _handle_staffcall_event(self, booth_id, action, data, channel_layer):
+        """StaffCall 도메인 이벤트 분기 처리"""
+
+        # 결제확인 완료: spring:booth:{id}:staffcall:completed
+        if action == "completed":
+            table_usage_id = data.get("table_usage_id")
+            call_type = data.get("call_type")
+
+            if call_type == "PAYMENT_CONFIRM" and table_usage_id:
+                try:
+                    from cart.services import confirm_payment_and_mark_ordered
+                    cart = confirm_payment_and_mark_ordered(table_usage_id=table_usage_id)
+                    self.stdout.write(self.style.SUCCESS(
+                        f"[결제확인] booth:{booth_id} table_usage:{table_usage_id} → Cart#{cart.id} ORDERED"
+                    ))
+                except Exception as e:
+                    self.stderr.write(self.style.ERROR(
+                        f"[결제확인 실패] booth:{booth_id} table_usage:{table_usage_id} → {e}"
+                    ))
+                    import traceback
+                    self.stderr.write(traceback.format_exc())
+
+        # 모든 staffcall 이벤트 → WebSocket 브로드캐스트
+        group_name = f"booth_{booth_id}.staffcall"
+        async_to_sync(channel_layer.group_send)(
+            group_name,
+            {"type": action, "data": data}
+        )
 
     def _handle_order_event(self, booth_id, action, data, channel_layer):
         """Order 도메인 이벤트 분기 처리"""

--- a/spring/src/main/java/com/example/spring/repository/staffcall/StaffCallRepository.java
+++ b/spring/src/main/java/com/example/spring/repository/staffcall/StaffCallRepository.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 public interface StaffCallRepository extends JpaRepository<StaffCall, Long> {
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT sc FROM StaffCall sc WHERE sc.tableId = :tableId AND sc.cartId = :cartId AND sc.callType = :callType")
+    @Query("SELECT sc FROM StaffCall sc WHERE sc.tableId = :tableId AND sc.cartId = :cartId AND sc.callType = :callType AND sc.status IN ('PENDING', 'ACCEPTED')")
     Optional<StaffCall> findByTableCartCallTypeForUpdate(
             @Param("tableId") Long tableId,
             @Param("cartId") Long cartId,


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->

스부 결제확인에서 뒤로가기 눌러서 콜잡은것 취소하고 다시 잡는과정에서 complete상태 중복처리 추가 
장고 레디스에 staffcall complete상태 구독하도록 추가 

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #225 
<!-- - ex) #3 -->