### PR TITLE
🐛 [Fix] - CSRF 에러 반환 오류 해결

### DIFF
--- a/django/cart/views.py
+++ b/django/cart/views.py
@@ -40,6 +40,7 @@ class CartAddAPIView(APIView):
     """
     POST /api/v3/django/cart/
     """
+    authentication_classes = []
 
     def post(self, request):
         serializer = AddToCartSerializer(data=request.data)
@@ -93,6 +94,7 @@ class CartDetailAPIView(APIView):
     """
     GET /api/v3/django/cart/detail/?table_usage_id=31
     """
+    authentication_classes = []
 
     def get(self, request):
         query_serializer = CartDetailQuerySerializer(data=request.query_params)
@@ -197,6 +199,7 @@ class CartUpdateQuantityAPIView(APIView):
     """
     PATCH /api/v3/django/cart/menu/
     """
+    authentication_classes = []
 
     def patch(self, request):
         serializer = UpdateQuantitySerializer(data=request.data)
@@ -230,6 +233,7 @@ class CartDeleteItemAPIView(APIView):
     """
     DELETE /api/v3/django/cart/menu/delete/
     """
+    authentication_classes = []
 
     def delete(self, request):
         serializer = DeleteItemSerializer(data=request.data)
@@ -258,6 +262,7 @@ class CartPaymentInfoAPIView(APIView):
     """
     POST /api/v3/django/cart/payment-info/
     """
+    authentication_classes = []
 
     def post(self, request):
         serializer = PaymentInfoSerializer(data=request.data)
@@ -297,6 +302,7 @@ class CartPaymentCancelAPIView(APIView):
     """
     POST /api/v3/django/cart/payment-cancel/
     """
+    authentication_classes = []
 
     def post(self, request):
         serializer = PaymentCancelSerializer(data=request.data)
@@ -330,6 +336,7 @@ class CartPaymentConfirmAPIView(APIView):
     POST /api/v3/django/cart/payment-confirm/
     운영진이 결제 확인 슬라이드 완료 시 호출
     """
+    authentication_classes = []
 
     def post(self, request):
         serializer = PaymentConfirmSerializer(data=request.data)
@@ -364,6 +371,7 @@ class CartResetAPIView(APIView):
     POST /api/v3/django/cart/reset/
     주문 완료 화면 처리 후 cart를 새 round로 초기화
     """
+    authentication_classes = []
 
     def post(self, request):
         serializer = CartResetSerializer(data=request.data)

--- a/django/coupon/views.py
+++ b/django/coupon/views.py
@@ -162,6 +162,8 @@ class CouponDownloadAPIView(APIView):
 
 # 손님용: 쿠폰 적용/취소
 class CouponApplyAPIView(APIView):
+    authentication_classes = []
+    
     def post(self, request):
         serializer = CouponApplySerializer(data=request.data)
         serializer.is_valid(raise_exception=True)


### PR DESCRIPTION
## 🔍 What is the PR?

- 고객용 API에서 발생하던 CSRF 403 에러 수정
- 고객용 APIView에 `authentication_classes = []` 추가하여 인증 비활성화


## 📍 PR Point

- 인증이 필요 없는 API에서도 전역 인증이 적용되면서 CSRF 검증이 발생하던 문제 해결
- 고객용 API와 운영진 API의 인증 흐름을 분리

## 📢 Notices

- 운영진 API는 기존처럼 검증 유지
- 고객용 API는 인증 없이 접근 가능하도록 분리

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #234 