### PR TITLE
fix: disable JWT authentication on customer APIs to prevent CSRF errors

### DIFF
--- a/django/menu/views.py
+++ b/django/menu/views.py
@@ -1,6 +1,6 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.parsers import MultiPartParser, FormParser, JSONParser
 from rest_framework import status
 from rest_framework.exceptions import ValidationError
@@ -273,7 +273,8 @@ class UserMenuListAPIView(APIView):
     사용자 메뉴판 조회 API
     GET /api/v3/django/booth/<int:booth_id>/menu-list/?table_number=xxx
     """
-    permission_classes = []  # 로그인 없이 접근 가능
+    authentication_classes = []  # JWT 인증 비활성화
+    permission_classes = [AllowAny]  # 로그인 없이 접근 가능
     def get(self, request, booth_id):
         table_num = request.GET.get('table_num')
         booth = get_object_or_404(Booth, pk=booth_id)

--- a/django/order/views.py
+++ b/django/order/views.py
@@ -15,6 +15,9 @@ from table.models import Table, TableUsage
 
 
 class OrderCancelAPIView(APIView):
+    """POST /api/v3/django/order/cancel/ - 운영자용 (인증 필요)"""
+    permission_classes = [IsAuthenticated]
+
     def post(self, request):
         event_data = request.data
         result = OrderService.handle_order_cancelled_event(event_data)
@@ -120,6 +123,7 @@ class TableOrderHistoryAPIView(APIView):
     - 세트메뉴는 개별 구성품이 아닌 세트메뉴 단위로 표시
     - 주문별(order_list) 구조로 반환
     """
+    authentication_classes = []
     permission_classes = [AllowAny]
 
     def get(self, request, table_usage_id):


### PR DESCRIPTION


<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

고객용 API `authentication_classes=[]` 추가

## 📍 PR Point

고객용 APIs:
- TableOrderHistoryAPIView: authentication_classes = [], permission_classes = []
- UserMenuListAPIView: authentication_classes = [], permission_classes = []

## ✅ Check List

- [ x] Merge 하는 브랜치가 올바른가?
- [ x] PR과 관련없는 변경사항이 없는가?
- [ x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues
#235 
 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #
<!-- - ex) #3 -->