### PR TITLE
[FIX]: 운영진 실시간 대쉬보드, 메뉴집계에서 테이블 이용료 FEE제외

### DIFF
--- a/django/order/consumers.py
+++ b/django/order/consumers.py
@@ -227,6 +227,7 @@ class AdminOrderManagementConsumer(KoreanAsyncJsonMixin, AsyncJsonWebsocketConsu
 
         def _query():
             # 리프 아이템: menu가 있고, 세트메뉴 부모(parent=None, setmenu≠None)가 아닌 것
+            # FEE 카테고리는 제외 (테이블 이용료는 메뉴 집계에서 제외)
             qs = (
                 OrderItem.objects
                 .filter(
@@ -236,6 +237,7 @@ class AdminOrderManagementConsumer(KoreanAsyncJsonMixin, AsyncJsonWebsocketConsu
                     menu__isnull=False,
                 )
                 .exclude(parent__isnull=True, setmenu__isnull=False)
+                .exclude(menu__category="FEE")
                 .select_related("menu")
             )
 
@@ -298,6 +300,10 @@ class AdminOrderManagementConsumer(KoreanAsyncJsonMixin, AsyncJsonWebsocketConsu
 
             items = []
             for item in top_items:
+                # FEE 카테고리는 운영진 대시보드에서 제외
+                if item.menu_id and item.menu and item.menu.category == "FEE":
+                    continue
+                
                 if item.setmenu_id:
                     # 세트메뉴 → 자식 OrderItem 개별 직렬화
                     set_menu_name = item.setmenu.name


### PR DESCRIPTION


The FEE menu items should appear in customer menus but not in admin order monitoring.

<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

운영진 실시간 대쉬보드, 메뉴집계에서 테이블 이용료 FEE제외

## 📍 PR Point

운영진 실시간 대쉬보드, 메뉴집계에서 테이블 이용료 FEE제외

## 📢 Notices

운영진 실시간 대쉬보드, 메뉴집계에서 테이블 이용료 FEE제외
## ✅ Check List

- [x ] Merge 하는 브랜치가 올바른가?
- [x ] PR과 관련없는 변경사항이 없는가?
- [ x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #
<!-- - ex) #3 -->