### PR TITLE
fix: menu aggregation shows only COOKING items

### DIFF
--- a/django/order/consumers.py
+++ b/django/order/consumers.py
@@ -221,9 +221,9 @@ class AdminOrderManagementConsumer(KoreanAsyncJsonMixin, AsyncJsonWebsocketConsu
         """
         DB에서 메뉴별 수량 집계 조회.
         리프 아이템만 대상 (세트메뉴 부모 제외, 자식 OrderItem + 일반 메뉴).
-        status가 COOKING, COOKED, SERVING인 것만 대상.
+        조리중(COOKING) 상태인 것만 대상. 조리완료되면 집계에서 제외됨.
         """
-        active_statuses = ["COOKING", "COOKED", "SERVING"]
+        active_statuses = ["COOKING"]  # 조리중인 것만
 
         def _query():
             # 리프 아이템: menu가 있고, 세트메뉴 부모(parent=None, setmenu≠None)가 아닌 것


### PR DESCRIPTION


<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

메뉴 집계에 조리중인것만 보이게 수정 

## 📍 PR Point

<!-- 나 이 부분 찢었다~! -->

## 📢 Notices

 <!-- 공용으로 사용하는(Extension) 부분에 대한 설명 -->

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #
<!-- - ex) #3 -->
#244 