### PR TITLE
🐛 [Fix] - CART WS 총매출 반영 해결

### DIFF
--- a/django/cart/services.py
+++ b/django/cart/services.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 from django.db import transaction
+from asgiref.sync import async_to_sync
 from django.db.models import F, Sum, Case, When, IntegerField, OuterRef, Subquery
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
@@ -723,6 +724,10 @@ def _finalize_payment_core(cart: Cart):
 
     booth = cart.table_usage.table.booth
     Booth.objects.filter(pk=booth.pk).update(total_revenues=F("total_revenues") + order_price)
+    
+    table_usage = TableUsage.objects.select_for_update().get(pk=cart.table_usage_id)
+    table_usage.accumulated_amount += order.order_price
+    table_usage.save(update_fields=["accumulated_amount"])
 
     return order
 
@@ -737,23 +742,39 @@ def confirm_payment_and_mark_ordered(*, table_usage_id: int) -> Cart:
             status_code=409,
         )
 
-    _finalize_payment_core(cart)
+    order = _finalize_payment_core(cart)
 
     cart.status = Cart.Status.ORDERED
     cart.pending_expires_at = None
     cart.save(update_fields=["status", "pending_expires_at"])
 
     final_table_usage_id = cart.table_usage_id
+    booth_id = cart.table_usage.table.booth_id
 
     from .services_ws import broadcast_cart_event
+    from order.cache import update_today_revenue
+    from channels.layers import get_channel_layer
+    from asgiref.sync import async_to_sync
 
-    transaction.on_commit(
-        lambda: broadcast_cart_event(
+    def _after_commit():
+        today_revenue = update_today_revenue(booth_id, order.order_price)
+
+        group_name = f"booth_{booth_id}.order"
+        async_to_sync(get_channel_layer().group_send)(
+            group_name,
+            {
+                "type": "total_sales_update",
+                "data": {"today_revenue": today_revenue},
+            }
+        )
+
+        broadcast_cart_event(
             table_usage_id=final_table_usage_id,
             event_type="CART_PAYMENT_CONFIRMED",
             message="결제가 확인되어 주문이 완료되었습니다.",
         )
-    )
+
+    transaction.on_commit(_after_commit)
 
     return cart
 


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

- 결제 완료 시 총매출이 0원으로 표시되던 문제 수정
- `confirm_payment_and_mark_ordered()`에서 주문 생성 후 총매출 캐시 갱신 로직 추가
- `total_sales_update` WebSocket 이벤트 전송 추가
- `TableUsage.accumulated_amount` 누적 금액 반영 로직 추가

## 📍 PR Point

- `_finalize_payment_core()` 호출 결과를 `order`로 받아 총매출 반영에 활용
- 기존 cart 이벤트와 함께 트랜잭션 커밋 이후 일관되게 브로드캐스트

## 📢 Notices

- 총매출 캐시는 Redis 기반, 캐시 미스 시 DB 기준으로 초기화됨
- WebSocket 그룹 이벤트 구조는 기존 order 서비스와 동일하게 맞춤

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

- #249 