### PR TITLE
🐛 [Fix] serving : resolve 500 error remove FK and align DB schema

### DIFF
--- a/spring/src/main/java/com/example/spring/controller/serving/ServingTaskController.java
+++ b/spring/src/main/java/com/example/spring/controller/serving/ServingTaskController.java
@@ -3,14 +3,15 @@ package com.example.spring.controller.serving;
 import com.example.spring.domain.serving.ServingTask;
 import com.example.spring.dto.serving.request.CatchCallRequest;
 import com.example.spring.dto.serving.response.ServingTaskResponse;
+import com.example.spring.security.ServerApiJwtFilter;
 import com.example.spring.service.serving.ServingTaskService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/serving")
@@ -19,30 +20,77 @@ public class ServingTaskController {
 
     private final ServingTaskService servingTaskService;
 
-    @GetMapping("/servingcall/{boothId}")
-    public ResponseEntity<List<ServingTaskResponse>> getPendingCalls(@PathVariable Long boothId) {
+    /**
+     * 신규 운영자용 API
+     * booth_id를 프론트에서 넘기지 않고 JWT 기준으로 조회
+     * GET /api/v3/spring/serving/servingcall
+     */
+    @GetMapping("/servingcall")
+    public ResponseEntity<List<ServingTaskResponse>> getMyPendingCalls(HttpServletRequest request) {
+        Long boothId = (Long) request.getAttribute(ServerApiJwtFilter.ATTR_BOOTH_ID);
+
+        if (boothId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
         List<ServingTask> tasks = servingTaskService.getPendingServingCalls(boothId);
         List<ServingTaskResponse> response = tasks.stream()
                 .map(ServingTaskResponse::from)
-                .collect(Collectors.toList());
+                .toList();
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 기존 경로 기반 API는 호환성 유지용
+     * 필요 없으면 추후 제거 가능
+     */
+    @GetMapping("/servingcall/{boothId}")
+    public ResponseEntity<List<ServingTaskResponse>> getPendingCalls(
+            @PathVariable Long boothId,
+            HttpServletRequest request
+    ) {
+        Long jwtBooth = (Long) request.getAttribute(ServerApiJwtFilter.ATTR_BOOTH_ID);
+
+        if (jwtBooth == null || !jwtBooth.equals(boothId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        List<ServingTask> tasks = servingTaskService.getPendingServingCalls(boothId);
+        List<ServingTaskResponse> response = tasks.stream()
+                .map(ServingTaskResponse::from)
+                .toList();
+
         return ResponseEntity.ok(response);
     }
 
     @PostMapping("/catchcall")
     public ResponseEntity<String> catchCall(
             @RequestParam Long taskId,
-            @RequestParam Long boothId,
-            @RequestBody(required = false) CatchCallRequest request) { // 🌟 프론트에서 Body를 안 보낼 경우 방어
+            @RequestBody CatchCallRequest request,
+            HttpServletRequest httpRequest
+    ) {
+        Long boothId = (Long) httpRequest.getAttribute(ServerApiJwtFilter.ATTR_BOOTH_ID);
 
-        String catchedBy = (request != null && request.getCatchedBy() != null) ? request.getCatchedBy() : "STAFF";
-        servingTaskService.catchCall(taskId, boothId, catchedBy);
+        if (boothId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("인증 정보가 없습니다.");
+        }
+
+        servingTaskService.catchCall(taskId, boothId, request.getCatchedBy());
         return ResponseEntity.ok("서빙 요청이 수락되었습니다.");
     }
 
     @PostMapping("/complete")
     public ResponseEntity<String> completeCall(
             @RequestParam Long taskId,
-            @RequestParam Long boothId) {
+            HttpServletRequest httpRequest
+    ) {
+        Long boothId = (Long) httpRequest.getAttribute(ServerApiJwtFilter.ATTR_BOOTH_ID);
+
+        if (boothId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("인증 정보가 없습니다.");
+        }
+
         servingTaskService.completeCall(taskId, boothId);
         return ResponseEntity.ok("서빙이 완료되었습니다.");
     }
@@ -50,24 +98,15 @@ public class ServingTaskController {
     @PostMapping("/cancel")
     public ResponseEntity<String> cancelCall(
             @RequestParam Long taskId,
-            @RequestParam Long boothId) {
+            HttpServletRequest httpRequest
+    ) {
+        Long boothId = (Long) httpRequest.getAttribute(ServerApiJwtFilter.ATTR_BOOTH_ID);
+
+        if (boothId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("인증 정보가 없습니다.");
+        }
+
         servingTaskService.cancelCall(taskId, boothId);
         return ResponseEntity.ok("서빙 수락이 취소되었습니다.");
-    }
-
-    // =========================================================================
-    // 🌟 추가된 부분: Service에서 던진 예외를 프론트엔드 친화적인 HTTP 상태 코드로 변환
-    // =========================================================================
-
-    @ExceptionHandler(IllegalStateException.class)
-    public ResponseEntity<String> handleIllegalStateException(IllegalStateException e) {
-        // 동시성 문제(이미 누가 수락함) 또는 상태 불일치 시 409 Conflict 반환
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
-    }
-
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException e) {
-        // 잘못된 taskId 등 존재하지 않는 데이터 접근 시 400 Bad Request 반환
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
     }
 }

--- a/spring/src/main/java/com/example/spring/domain/serving/ServingTask.java
+++ b/spring/src/main/java/com/example/spring/domain/serving/ServingTask.java
@@ -16,9 +16,14 @@ public class ServingTask {
     private Long id;
 
     /**
+     * 운영자 인증 기반 조회를 위해 serving_task 자체에 booth_id를 저장
+     */
+    @Column(name = "booth_id", nullable = false)
+    private Long boothId;
+
+    /**
      * Django가 관리하는 orderitem 테이블은
-     * Spring에서 JPA 연관관계로 직접 물지 않고,
-     * FK 값(ID)만 저장합니다.
+     * Spring에서 JPA 연관관계로 직접 물지 않고 FK 값(ID)만 저장
      */
     @Column(name = "orderitem", nullable = false)
     private Long orderItemId;
@@ -49,7 +54,8 @@ public class ServingTask {
     private String key;
 
     @Builder
-    public ServingTask(Long orderItemId, String key) {
+    public ServingTask(Long boothId, Long orderItemId, String key) {
+        this.boothId = boothId;
         this.orderItemId = orderItemId;
         this.status = ServingStatus.SERVE_REQUESTED;
         this.key = key;

--- a/spring/src/main/java/com/example/spring/redis/RedisSubscriber.java
+++ b/spring/src/main/java/com/example/spring/redis/RedisSubscriber.java
@@ -15,11 +15,12 @@ public class RedisSubscriber implements MessageListener {
         this.eventPublisher = eventPublisher;
     }
 
-@Override
-public void onMessage(Message message, byte[] pattern) {
-    String publishedMessage = new String(message.getBody());
-    String channel = new String(message.getChannel());
-    System.out.println("[구독 패턴] " + channel + " → 데이터: " + publishedMessage);
-    eventPublisher.publishEvent(new RedisMessageEvent(channel, publishedMessage));
-}
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        String publishedMessage = new String(message.getBody());
+        String channel = new String(message.getChannel());
+
+        System.out.println("[구독 패턴] " + channel + " → 데이터: " + publishedMessage);
+        eventPublisher.publishEvent(new RedisMessageEvent(channel, publishedMessage));
+    }
 }

--- a/spring/src/main/java/com/example/spring/repository/serving/ServingTaskRepository.java
+++ b/spring/src/main/java/com/example/spring/repository/serving/ServingTaskRepository.java
@@ -9,8 +9,8 @@ import java.util.List;
 public interface ServingTaskRepository extends JpaRepository<ServingTask, Long> {
 
     /**
-     * Django의 orderitem 테이블과 조인하지 않고
-     * serving_task 자체만 조회합니다.
+     * 운영자 인증으로 추출한 booth_id 기준으로
+     * 해당 부스의 서빙 대기 목록만 조회
      */
-    List<ServingTask> findByStatusOrderByRequestedAtAsc(ServingStatus status);
+    List<ServingTask> findByBoothIdAndStatusOrderByRequestedAtAsc(Long boothId, ServingStatus status);
 }

--- a/spring/src/main/java/com/example/spring/security/ServerApiJwtFilter.java
+++ b/spring/src/main/java/com/example/spring/security/ServerApiJwtFilter.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 /**
- * {@code /server/**} 서버(직원) API — (기본) access_token 쿠키 필수
+ * {@code /server/**}, {@code /serving/**} 서버(직원/서빙) API — (기본) access_token 쿠키 필수
  * <p>
  * 단, 직원 호출 등록(emit)은 인증을 강제하지 않음
  */
@@ -31,11 +31,15 @@ public class ServerApiJwtFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
+
         String path = request.getRequestURI();
-        if (!path.startsWith("/server/")) {
+
+        // 기존 개발자가 만들어둔 isProtectedPath 활용하여 /server/ 및 /serving/ 모두 필터 적용
+        if (!isProtectedPath(path)) {
             filterChain.doFilter(request, response);
             return;
         }
+
         if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
             filterChain.doFilter(request, response);
             return;
@@ -55,6 +59,7 @@ public class ServerApiJwtFilter extends OncePerRequestFilter {
             response.getWriter().write("{\"message\":\"인증이 필요합니다.\"}");
             return;
         }
+
         try {
             Long boothId = jwtUtil.getBoothIdFromToken(token);
             request.setAttribute(ATTR_BOOTH_ID, boothId);
@@ -66,7 +71,12 @@ public class ServerApiJwtFilter extends OncePerRequestFilter {
             response.getWriter().write("{\"message\":\"유효하지 않은 토큰입니다.\"}");
             return;
         }
+
         filterChain.doFilter(request, response);
+    }
+
+    private boolean isProtectedPath(String path) {
+        return path.startsWith("/server/") || path.startsWith("/serving/");
     }
 
     private boolean isStaffCallPublicPath(String path) {

--- a/spring/src/main/java/com/example/spring/service/serving/ServingTaskEventListener.java
+++ b/spring/src/main/java/com/example/spring/service/serving/ServingTaskEventListener.java
@@ -1,11 +1,7 @@
 package com.example.spring.service.serving;
 
-import com.example.spring.domain.serving.ServingTask;
 import com.example.spring.dto.redis.OrderCookedMessageDto;
-import com.example.spring.dto.serving.response.ServingTaskResponse;
 import com.example.spring.event.RedisMessageEvent;
-import com.example.spring.repository.serving.ServingTaskRepository;
-import com.example.spring.websocket.ServingWebSocketHandler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,10 +16,8 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class ServingTaskEventListener {
 
-    private final ServingTaskRepository servingTaskRepository;
-    // 🌟 OrderItem 연관관계를 끊었으므로 OrderItemRepository 제거
+    private final ServingTaskService servingTaskService;
     private final ObjectMapper objectMapper;
-    private final ServingWebSocketHandler webSocketHandler;
 
     @EventListener
     @Transactional
@@ -33,27 +27,31 @@ public class ServingTaskEventListener {
 
         if (channel.startsWith("django:booth:") && channel.endsWith(":order:cooked")) {
             try {
+                Long boothId = extractBoothId(channel);
                 OrderCookedMessageDto dto = objectMapper.readValue(message, OrderCookedMessageDto.class);
 
-                // 🌟 Spring에서 직접 OrderItem을 DB에서 검증하던 로직 제거 (Django 소유 테이블)
+                servingTaskService.createNewServingTask(
+                        boothId,
+                        dto.getOrderItemId(),
+                        UUID.randomUUID().toString()
+                );
 
-                ServingTask servingTask = ServingTask.builder()
-                        .orderItemId(dto.getOrderItemId())
-                        .key(UUID.randomUUID().toString()) // 기존 UUID 생성 로직 유지
-                        .build();
-
-                servingTaskRepository.save(servingTask);
-                log.info("[서빙 태스크 생성 완료] OrderItemId: {}", dto.getOrderItemId());
-
-                // [웹소켓 추가 부분] DB 저장 끝났으니 프론트 화면으로 바로 쏴주기!
-                ServingTaskResponse responseDto = ServingTaskResponse.from(servingTask);
-
-                // 🌟 JSON 타입 분류("NEW_CALL")를 포함하여 프론트엔드 친화적으로 브로드캐스트
-                webSocketHandler.broadcastEvent("NEW_CALL", responseDto);
+                log.info("[서빙 태스크 생성 완료] boothId={}, orderItemId={}", boothId, dto.getOrderItemId());
 
             } catch (Exception e) {
-                log.error("[Redis 메시지 처리 실패]", e);
+                log.error("[Redis 메시지 처리 실패] channel={}, message={}", channel, message, e);
             }
         }
+    }
+
+    /**
+     * 예: django:booth:3:order:cooked -> 3 추출
+     */
+    private Long extractBoothId(String channel) {
+        String[] parts = channel.split(":");
+        if (parts.length < 5) {
+            throw new IllegalArgumentException("유효하지 않은 채널 형식입니다: " + channel);
+        }
+        return Long.valueOf(parts[2]);
     }
 }

--- a/spring/src/main/java/com/example/spring/service/serving/ServingTaskService.java
+++ b/spring/src/main/java/com/example/spring/service/serving/ServingTaskService.java
@@ -1,11 +1,11 @@
 package com.example.spring.service.serving;
 
-import com.example.spring.websocket.ServingWebSocketHandler;
 import com.example.spring.domain.serving.ServingStatus;
 import com.example.spring.domain.serving.ServingTask;
 import com.example.spring.dto.redis.ServingStatusMessageDto;
-import com.example.spring.dto.serving.response.ServingTaskResponse; // 🌟 이 부분이 추가되었습니다!
+import com.example.spring.dto.serving.response.ServingTaskResponse;
 import com.example.spring.repository.serving.ServingTaskRepository;
+import com.example.spring.websocket.ServingWebSocketHandler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,10 +29,12 @@ public class ServingTaskService {
 
     @Transactional(readOnly = true)
     public List<ServingTask> getPendingServingCalls(Long boothId) {
-        return servingTaskRepository.findByStatusOrderByRequestedAtAsc(ServingStatus.SERVE_REQUESTED);
+        return servingTaskRepository.findByBoothIdAndStatusOrderByRequestedAtAsc(
+                boothId,
+                ServingStatus.SERVE_REQUESTED
+        );
     }
 
-    // 🌟 수정됨: 서빙 수락 (Redis 선착순 락 적용)
     @Transactional
     public void catchCall(Long taskId, Long boothId, String catchedBy) {
         String lockKey = "lock:serving_task:" + taskId;
@@ -47,6 +49,10 @@ public class ServingTaskService {
             ServingTask task = servingTaskRepository.findById(taskId)
                     .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 서빙 요청입니다. taskId=" + taskId));
 
+            if (!task.getBoothId().equals(boothId)) {
+                throw new IllegalStateException("해당 부스의 서빙 요청이 아닙니다.");
+            }
+
             if (task.getStatus() != ServingStatus.SERVE_REQUESTED) {
                 throw new IllegalStateException("이미 처리된 요청입니다.");
             }
@@ -54,10 +60,7 @@ public class ServingTaskService {
             String actor = (catchedBy != null && !catchedBy.isEmpty()) ? catchedBy : "STAFF";
             task.acceptServing(actor);
 
-            // 1. 장고 측으로 Redis 메시지 발행
             publishToDjango(boothId, "serving", task.getOrderItemId(), actor);
-
-            // 2. 🌟 프론트엔드로 웹소켓 브로드캐스트 (CATCH_CALL 이벤트)
             webSocketHandler.broadcastEvent("CATCH_CALL", ServingTaskResponse.from(task));
 
         } finally {
@@ -67,39 +70,49 @@ public class ServingTaskService {
 
     @Transactional
     public void completeCall(Long taskId, Long boothId) {
-        ServingTask task = servingTaskRepository.findById(taskId).orElseThrow();
+        ServingTask task = servingTaskRepository.findById(taskId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 서빙 요청입니다. taskId=" + taskId));
+
+        if (!task.getBoothId().equals(boothId)) {
+            throw new IllegalStateException("해당 부스의 서빙 요청이 아닙니다.");
+        }
+
         task.completeServing();
 
         publishToDjango(boothId, "served", task.getOrderItemId(), null);
-
-        // 🌟 프론트엔드로 웹소켓 브로드캐스트 (COMPLETE_CALL 이벤트)
         webSocketHandler.broadcastEvent("COMPLETE_CALL", ServingTaskResponse.from(task));
     }
 
     @Transactional
     public void cancelCall(Long taskId, Long boothId) {
-        ServingTask task = servingTaskRepository.findById(taskId).orElseThrow();
+        ServingTask task = servingTaskRepository.findById(taskId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 서빙 요청입니다. taskId=" + taskId));
+
+        if (!task.getBoothId().equals(boothId)) {
+            throw new IllegalStateException("해당 부스의 서빙 요청이 아닙니다.");
+        }
+
         task.cancelServing();
 
         publishToDjango(boothId, "cooked", task.getOrderItemId(), null);
-
-        // 🌟 프론트엔드로 웹소켓 브로드캐스트 (CANCEL_CALL 이벤트)
         webSocketHandler.broadcastEvent("CANCEL_CALL", ServingTaskResponse.from(task));
     }
 
-    // 장고(Django) -> 스프링(Spring) : 새 조리 완료 알림이 왔을 때 호출될 메서드
+    /**
+     * Django -> Spring : 조리 완료 알림 수신 시 새 serving_task 생성
+     */
     @Transactional
-    public void createNewServingTask(Long orderItemId, String key) {
-        // 1. 새 태스크 생성 및 저장
+    public void createNewServingTask(Long boothId, Long orderItemId, String key) {
         ServingTask newTask = ServingTask.builder()
+                .boothId(boothId)
                 .orderItemId(orderItemId)
                 .key(key)
                 .build();
+
         servingTaskRepository.save(newTask);
 
-        // 2. 🌟 프론트엔드로 웹소켓 브로드캐스트 (NEW_CALL 이벤트)
         webSocketHandler.broadcastEvent("NEW_CALL", ServingTaskResponse.from(newTask));
-        log.info("[새 서빙 요청 생성 및 브로드캐스트] orderItemId: {}", orderItemId);
+        log.info("[새 서빙 요청 생성 및 브로드캐스트] boothId={}, orderItemId={}", boothId, orderItemId);
     }
 
     private void publishToDjango(Long boothId, String status, Long orderItemId, String catchedBy) {

--- a/spring/src/main/java/com/example/spring/websocket/ServingWebSocketHandler.java
+++ b/spring/src/main/java/com/example/spring/websocket/ServingWebSocketHandler.java
@@ -17,11 +17,11 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor // 🌟 ObjectMapper 주입을 위해 추가
+@RequiredArgsConstructor
 public class ServingWebSocketHandler extends TextWebSocketHandler {
 
     private final Set<WebSocketSession> sessions = ConcurrentHashMap.newKeySet();
-    private final ObjectMapper objectMapper; // 🌟 JSON 변환용 객체
+    private final ObjectMapper objectMapper;
 
     @Override
     public void afterConnectionEstablished(WebSocketSession session) {
@@ -35,7 +35,6 @@ public class ServingWebSocketHandler extends TextWebSocketHandler {
         log.info("[웹소켓 해제] 태블릿 연결 끊김: {}", session.getId());
     }
 
-    // 기존의 단순 문자열 전송 메서드
     public void broadcastMessage(String message) {
         TextMessage textMessage = new TextMessage(message);
         for (WebSocketSession session : sessions) {
@@ -49,12 +48,11 @@ public class ServingWebSocketHandler extends TextWebSocketHandler {
         }
     }
 
-    // 🌟 추가된 부분: 프론트엔드가 파싱하기 편하도록 JSON 구조(type, data)로 쏴주는 메서드
     public void broadcastEvent(String eventType, Object data) {
         try {
             Map<String, Object> payload = new HashMap<>();
-            payload.put("type", eventType); // 예: "CATCH_CALL", "NEW_CALL"
-            payload.put("data", data);      // 예: ServingTaskResponse 객체
+            payload.put("type", eventType);
+            payload.put("data", data);
 
             String jsonMessage = objectMapper.writeValueAsString(payload);
             broadcastMessage(jsonMessage);


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

[FIX] Serving API booth 기반 구조 개선 및 FK 제거

## 📍 PR Point

기존 ServingTask에서 Django가 관리하는 `orderitem` 테이블을 JPA FK로 직접 참조하고 있었음.

이로 인해:
- Spring ↔ Django 간 강한 결합 발생
- 배포 환경에서 FK 참조 문제로 500 에러 발생
- DB 스키마 불일치로 장애 발생
-
## 🔨 주요 변경 사항

### 1. Entity 구조 변경
- `@ManyToOne OrderItem` 제거
- `Long orderItemId` 필드로 변경
- `booth_id` 컬럼 추가

---

### 2. Repository 변경
- join fetch 제거
- `findByStatusOrderByRequestedAtAsc` → booth_id 기반 조회로 변경

---

### 3. Service 로직 변경
- Django FK 의존 로직 제거
- Redis 이벤트 기반 ServingTask 생성 방식으로 전환
- booth_id 기반 데이터 처리

---

### 4. API 구조 개선
기존:

GET /serving/servingcall/{booth_id}


변경:

GET /serving/servingcall


- JWT에서 booth_id 추출하여 처리

---

### 5. WebSocket 개선
- 이벤트 타입 기반 메시지 구조 추가

```json
{
  "type": "NEW_CALL",
  "data": { ... }
}
```



## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #253 
<!-- - ex) #3 -->