### PR TITLE
[feat]: 테이블 병합 후 주문 재조회 및 실시간 브로드캐스트 검증

### DIFF
--- a/django/order/consumers.py
+++ b/django/order/consumers.py
@@ -25,7 +25,8 @@ class AdminOrderManagementConsumer(KoreanAsyncJsonMixin, AsyncJsonWebsocketConsu
       ⑤ ORDER_COMPLETED       – 전체 서빙 완료
       ⑥ MENU_AGGREGATION      – 메뉴별 실시간 집계
       ⑦ TOTAL_SALES_UPDATE    – 총매출 갱신
-      ⑧ ADMIN_TABLE_RESET     – 테이블 초기화 (주문 제거)
+      ⑧ ADMIN_TABLE_RESET     – 테이블 초기화 (주문 갱신)
+      ⑨ ADMIN_TABLE_MERGE     – 테이블 병합 (주문 갱신)
     """
 
     # ───────────────────────────────────────────
@@ -322,6 +323,39 @@ class AdminOrderManagementConsumer(KoreanAsyncJsonMixin, AsyncJsonWebsocketConsu
             "timestamp": timezone.localtime().isoformat(),
             "data": {
                 "table_nums": table_nums,
+                "count": data.get("count", 0),
+                "total_sales": total_sales,
+                "orders": serialized_orders,  # ← 현재 활성 주문들
+            },
+        })
+
+    # ───────────────────────────────────────────
+    # ⑨ ADMIN_TABLE_MERGE (group_send handler)
+    # ───────────────────────────────────────────
+    async def admin_table_merge(self, event):
+        """테이블 병합 이벤트 수신 → 현재 주문 목록 재전송 (병합되지 않은 테이블들)"""
+        data = event.get("data", {})
+        table_nums = data.get("table_nums", [])
+        representative_table = data.get("representative_table")
+        logger.warning(f"🔗 [Order WS] 테이블 병합 - table_nums={table_nums}, rep={representative_table}")
+        
+        # 현재 활성 주문 목록 재조회 (ended_at이 NULL인 테이블만)
+        orders = await self._get_active_orders()
+        logger.warning(f"🔗 [Order WS] 재조회됨: {len(orders)}개 주문")
+        
+        serialized_orders = []
+        for order in orders:
+            serialized_orders.append(await self._serialize_order(order))
+
+        total_sales = await self._get_total_sales()
+
+        # 클라이언트로 업데이트된 주문 목록 전송
+        await self.send_json({
+            "type": "ADMIN_TABLE_MERGE",
+            "timestamp": timezone.localtime().isoformat(),
+            "data": {
+                "table_nums": table_nums,
+                "representative_table": representative_table,
                 "count": data.get("count", 0),
                 "total_sales": total_sales,
                 "orders": serialized_orders,  # ← 현재 활성 주문들

--- a/django/order/tests.py
+++ b/django/order/tests.py
@@ -408,3 +408,87 @@ async def test_table_reset_websocket_broadcast(settings):
     assert reset_response["data"]["orders"][0]["order_id"] == order2.id
 
     await communicator.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_table_merge_websocket_broadcast(settings):
+    """테이블 병합 시 WebSocket으로 실시간 알림이 전송되고 주문이 갱신되는지 확인"""
+    settings.CHANNEL_LAYERS = {"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}}
+
+    user = await sync_to_async(User.objects.create_user)(username="admin_table_merge", password="password")
+    booth = await sync_to_async(Booth.objects.create)(
+        user=user,
+        name="테스트부스",
+        account="1234567890",
+        depositor="홍길동",
+        bank="테스트은행",
+        table_max_cnt=10,
+        table_limit_hours=2,
+        seat_type="NO",
+    )
+    table1 = await sync_to_async(Table.objects.create)(booth=booth, table_num=1)
+    table2 = await sync_to_async(Table.objects.create)(booth=booth, table_num=2)
+    table3 = await sync_to_async(Table.objects.create)(booth=booth, table_num=3)
+    
+    # 테이블 1, 2: 사용 중
+    table_usage1 = await sync_to_async(TableUsage.objects.create)(table=table1, started_at=timezone.now())
+    await sync_to_async(lambda: Table.objects.filter(pk=table1.id).update(status="IN_USE"))()
+    
+    table_usage2 = await sync_to_async(TableUsage.objects.create)(table=table2, started_at=timezone.now())
+    await sync_to_async(lambda: Table.objects.filter(pk=table2.id).update(status="IN_USE"))()
+    
+    # 테이블 3: 사용 중
+    table_usage3 = await sync_to_async(TableUsage.objects.create)(table=table3, started_at=timezone.now())
+    await sync_to_async(lambda: Table.objects.filter(pk=table3.id).update(status="IN_USE"))()
+    
+    menu = await sync_to_async(Menu.objects.create)(
+        booth=booth,
+        name="테스트메뉴",
+        category="MENU",
+        price=5000,
+        stock=100,
+    )
+
+    # 각 테이블의 주문
+    order1 = await sync_to_async(Order.objects.create)(
+        order_price=10000,
+        order_status="PAID",
+        table_usage=table_usage1,
+    )
+    order2 = await sync_to_async(Order.objects.create)(
+        order_price=10000,
+        order_status="PAID",
+        table_usage=table_usage2,
+    )
+    order3 = await sync_to_async(Order.objects.create)(
+        order_price=10000,
+        order_status="PAID",
+        table_usage=table_usage3,
+    )
+    
+    # WebSocket 연결
+    communicator = WebsocketCommunicator(application, "/ws/django/booth/orders/management/")
+    communicator.scope["user"] = user
+    connected, _ = await communicator.connect()
+    assert connected
+
+    # 초기 스냅샷 수신 (3개 주문)
+    snapshot = await receive_until_type(communicator, "ADMIN_ORDER_SNAPSHOT")
+    print(f"✅ 처음: {len(snapshot['data']['orders'])}개 주문")
+    assert len(snapshot["data"]["orders"]) == 3
+
+    # 테이블 1, 2 병합
+    from table.services import TableService
+    await sync_to_async(TableService.merge_tables)(booth, [1, 2])
+
+    # WebSocket에서 ADMIN_TABLE_MERGE 메시지 수신
+    merge_response = await receive_until_type(communicator, "ADMIN_TABLE_MERGE")
+    print(f"✅ 테이블 병합 메시지 수신 - table_nums={merge_response['data']['table_nums']}, rep={merge_response['data']['representative_table']}")
+    print(f"✅ 테이블 1,2 병합 후: {len(merge_response['data']['orders'])}개 주문 (order3 포함 모두)")
+    
+    # 병합되어도 주문은 유지되어야 함 (order1, order2, order3 모두 남음)
+    assert merge_response["data"]["representative_table"] == 1
+    assert len(merge_response["data"]["orders"]) == 3  # 모든 주문 유지
+
+    await communicator.disconnect()

--- a/django/table/services.py
+++ b/django/table/services.py
@@ -564,4 +564,13 @@ class TableService:
                 'count': all_tables_count,
             }
         })
+        # 주문 관리 대시보드에도 알림 (WebSocket 실시간 반영용)
+        TableService._broadcast_to_order_group(booth.pk, {
+            'type': 'admin_table_merge',
+            'data': {
+                'table_nums': merged_table_nums,
+                'representative_table': representative_table.table_num,
+                'count': all_tables_count,
+            }
+        })
         return representative_table.table_num, all_tables_count


### PR DESCRIPTION

<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->
- admin_table_merge 핸들러에서 병합된 테이블의 모든 활성 주문 재조회
- 재조회된 주문 목록을 클라이언트로 실시간 전송
- 테스트: 테이블 1,2 병합 후 3개 주문 모두 유지 확인


## 📍 PR Point

<!-- 나 이 부분 찢었다~! -->

## 📢 Notices

 <!-- 공용으로 사용하는(Extension) 부분에 대한 설명 -->

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #244
<!-- - ex) #3 -->