### PR TITLE
🐛 [Fix] - 장바구니 응답에 image 필드 누락 수정 및 payload 통일

### DIFF
--- a/django/cart/services.py
+++ b/django/cart/services.py
@@ -127,6 +127,46 @@ def recalc_cart_price(cart: Cart) -> int:
     return cart.cart_price
 
 
+# 장바구니 item 이미지 URL 공통 헬퍼
+def get_cart_item_image_url(item: CartItem) -> str | None:
+    """
+    CartItem이 단일 메뉴인지 세트메뉴인지에 따라 이미지 URL 반환
+    """
+    if item.menu_id and item.menu and item.menu.image:
+        return item.menu.image.url
+
+    if item.setmenu_id and item.setmenu and item.setmenu.image:
+        return item.setmenu.image.url
+
+    return None
+
+
+#  장바구니 item payload 공통 헬퍼
+# REST / WS 둘 다 같은 구조로 맞추기 위해 사용
+def build_cart_item_payload(item: CartItem) -> dict:
+    if item.menu_id:
+        name = item.menu.name
+        unit_price = int(item.menu.price)
+        is_sold_out = item.menu.stock <= 0
+    else:
+        name = item.setmenu.name
+        unit_price = int(item.setmenu.price)
+        is_sold_out = False
+
+    return {
+        "id": item.id,
+        "type": item.type,
+        "menu_id": item.menu_id,
+        "set_menu_id": item.setmenu_id,
+        "name": name,
+        "image": get_cart_item_image_url(item),
+        "unit_price": unit_price,
+        "quantity": item.quantity,
+        "line_price": item.line_price,
+        "is_sold_out": is_sold_out,
+    }
+
+
 def _validate_menu_stock(menu: Menu, want_qty: int):
     if menu.stock < want_qty:
         raise CartError(

--- a/django/cart/services_ws.py
+++ b/django/cart/services_ws.py
@@ -9,7 +9,8 @@ from cart.services import (
     recalc_cart_price,
     _calc_discount,
     _is_fee_booth,         
-    _can_add_fee_in_this_round
+    _can_add_fee_in_this_round,
+    build_cart_item_payload,
 )
 
 logger = logging.getLogger(__name__)
@@ -22,26 +23,8 @@ def build_cart_snapshot_data(table_usage_id: int):
 
     items = []
     for it in cart.items.select_related("menu", "setmenu"):
-        if it.menu_id:
-            name = it.menu.name
-            unit_price = int(it.menu.price)
-            is_sold_out = it.menu.stock <= 0
-        else:
-            name = it.setmenu.name
-            unit_price = int(it.setmenu.price)
-            is_sold_out = False
-
-        items.append({
-            "id": it.id,
-            "type": it.type,
-            "menu_id": it.menu_id,
-            "set_menu_id": it.setmenu_id,
-            "name": name,
-            "unit_price": unit_price,
-            "quantity": it.quantity,
-            "line_price": it.line_price,
-            "is_sold_out": is_sold_out,
-        })
+        # 기존 직접 dict 만들던 부분 대신 공통 payload 사용
+        items.append(build_cart_item_payload(it))
 
     subtotal = cart.cart_price
 

--- a/django/cart/views.py
+++ b/django/cart/views.py
@@ -17,7 +17,8 @@ from .services import (
     confirm_payment_and_mark_ordered,
     reset_ordered_cart,
     _is_fee_booth,
-    _can_add_fee_in_this_round 
+    _can_add_fee_in_this_round,
+    build_cart_item_payload,
 )
 from .services_ws import *
 
@@ -76,14 +77,7 @@ class CartAddAPIView(APIView):
                         "cart_price": cart.cart_price,
                         "round": cart.round,
                     },
-                    "item": {
-                        "id": item.id,
-                        "type": item.type,
-                        "menu_id": item.menu_id,
-                        "set_menu_id": item.setmenu_id,
-                        "quantity": item.quantity,
-                        "line_price": item.line_price,
-                    },
+                    "item": build_cart_item_payload(item),
                 },
             },
             status=200,
@@ -117,28 +111,7 @@ class CartDetailAPIView(APIView):
 
         items = []
         for it in cart.items.select_related("menu", "setmenu"):
-            if it.menu_id:
-                name = it.menu.name
-                unit_price = int(it.menu.price)
-                is_sold_out = it.menu.stock <= 0
-            else:
-                name = it.setmenu.name
-                unit_price = int(it.setmenu.price)
-                is_sold_out = False
-
-            items.append(
-                {
-                    "id": it.id,
-                    "type": it.type,
-                    "menu_id": it.menu_id,
-                    "set_menu_id": it.setmenu_id,
-                    "name": name,
-                    "unit_price": unit_price,
-                    "quantity": it.quantity,
-                    "line_price": it.line_price,
-                    "is_sold_out": is_sold_out,
-                }
-            )
+            items.append(build_cart_item_payload(it))   # 여기 수정
 
         coupon = {
             "applied": False,
@@ -224,8 +197,7 @@ class CartUpdateQuantityAPIView(APIView):
 
         data = {"cart_price": cart.cart_price}
         if item:
-            data["item"] = {"id": item.id, "quantity": item.quantity, "line_price": item.line_price}
-
+            data["item"] = build_cart_item_payload(item)
         return Response({"message": "수량 변경 성공", "data": data}, status=200)
 
 


### PR DESCRIPTION
## 🔍 What is the PR?

- 장바구니 조회(REST) 및 WebSocket 응답에서 메뉴 이미지(image)가 내려오지 않던 문제 수정
- Cart item payload 생성 로직을 `build_cart_item_payload()`로 통일
- 단일 메뉴 / 세트 메뉴 모두 image 필드 포함되도록 처리
- CartAdd, CartUpdate API 응답도 동일한 payload 구조로 통일

## 📍 PR Point

- 장바구니 관련 모든 응답(REST + WS)의 item 구조를 하나의 함수로 통일하여 유지보수성 개선
- menu API와 동일한 방식으로 일치

## 📢 Notices

- 프론트에서 image 필드는 `/media/...` 형태의 상대경로로 전달됨
- 기존 menu API와 동일한 방식이므로 별도 도메인 prefix 없이 사용 가능

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

- #266 