### PR TITLE
fix: 세트메뉴 응답 필드명 수정 (set_items_output -> set_items)

### DIFF
--- a/django/menu/serializers.py
+++ b/django/menu/serializers.py
@@ -225,7 +225,7 @@ class SetMenuSerializer(serializers.ModelSerializer):
             'required': '가격은 필수 항목입니다.',
         }
     )
-    set_items = serializers.ListField(
+    set_items_input = serializers.ListField(
         child=serializers.DictField(),
         write_only=True,
         error_messages={
@@ -244,7 +244,7 @@ class SetMenuSerializer(serializers.ModelSerializer):
     # 출력 필드
     set_id = serializers.IntegerField(source='id', read_only=True)
     booth_id = serializers.IntegerField(source='booth.pk', read_only=True)
-    set_items_output = SetMenuItemOutputSerializer(source='items', many=True, read_only=True)
+    set_items = SetMenuItemOutputSerializer(source='items', many=True, read_only=True)
     origin_price = serializers.SerializerMethodField()
     is_soldout = serializers.SerializerMethodField()
     
@@ -252,7 +252,7 @@ class SetMenuSerializer(serializers.ModelSerializer):
         model = SetMenu
         fields = [
             'set_id', 'booth_id', 'name', 'category', 'description',
-            'price', 'image', 'set_items', 'set_items_output',
+            'price', 'image', 'set_items_input', 'set_items',
             'origin_price', 'is_soldout', 'created_at', 'updated_at'
         ]
         read_only_fields = ['set_id', 'booth_id', 'category', 'created_at', 'updated_at']
@@ -271,7 +271,7 @@ class SetMenuSerializer(serializers.ModelSerializer):
                 return True
         return False
     
-    def validate_set_items(self, value):
+    def validate_set_items_input(self, value):
         """세트 구성 항목 유효성 검사"""
         # 빈 배열 체크
         if not value or len(value) == 0:
@@ -290,13 +290,6 @@ class SetMenuSerializer(serializers.ModelSerializer):
             validated_items.append(item_serializer.validated_data)
         
         return validated_items
-    
-    def to_representation(self, instance):
-        """응답 포맷 조정 (set_items_output -> set_items)"""
-        data = super().to_representation(instance)
-        # set_items_output을 set_items로 매핑
-        data['set_items'] = data.pop('set_items_output', [])
-        return data
 
 
 class SetMenuUpdateSerializer(serializers.ModelSerializer):
@@ -330,7 +323,7 @@ class SetMenuUpdateSerializer(serializers.ModelSerializer):
             'invalid': '가격은 정수여야 합니다.',
         }
     )
-    set_items = serializers.ListField(
+    set_items_input = serializers.ListField(
         child=serializers.DictField(),
         required=False,
         error_messages={
@@ -346,7 +339,7 @@ class SetMenuUpdateSerializer(serializers.ModelSerializer):
     # 출력 필드
     set_id = serializers.IntegerField(source='id', read_only=True)
     booth_id = serializers.IntegerField(source='booth.pk', read_only=True)
-    set_items_output = SetMenuItemOutputSerializer(source='items', many=True, read_only=True)
+    set_items = SetMenuItemOutputSerializer(source='items', many=True, read_only=True)
     origin_price = serializers.SerializerMethodField()
     is_soldout = serializers.SerializerMethodField()
     
@@ -354,7 +347,7 @@ class SetMenuUpdateSerializer(serializers.ModelSerializer):
         model = SetMenu
         fields = [
             'set_id', 'booth_id', 'name', 'category', 'description',
-            'price', 'image', 'image_delete', 'set_items', 'set_items_output',
+            'price', 'image', 'image_delete', 'set_items_input', 'set_items',
             'origin_price', 'is_soldout', 'created_at', 'updated_at'
         ]
         read_only_fields = ['set_id', 'booth_id', 'category', 'image', 'created_at', 'updated_at']
@@ -373,7 +366,7 @@ class SetMenuUpdateSerializer(serializers.ModelSerializer):
                 return True
         return False
     
-    def validate_set_items(self, value):
+    def validate_set_items_input(self, value):
         """세트 구성 항목 유효성 검사"""
         # 빈 배열 체크 (수정 시에도 최소 1개 필요)
         if not value or len(value) == 0:
@@ -402,9 +395,3 @@ class SetMenuUpdateSerializer(serializers.ModelSerializer):
                     'image': '이미지는 수정할 수 없습니다. image_delete로 삭제만 가능합니다.'
                 })
         return attrs
-    
-    def to_representation(self, instance):
-        """응답 포맷 조정 (set_items_output -> set_items)"""
-        data = super().to_representation(instance)
-        data['set_items'] = data.pop('set_items_output', [])
-        return data

--- a/django/menu/services.py
+++ b/django/menu/services.py
@@ -58,7 +58,7 @@ class SetMenuService:
         세트메뉴 생성
         - SetMenu + SetMenuItem 함께 생성
         """
-        set_items_data = validated_data.pop('set_items')
+        set_items_data = validated_data.pop('set_items_input')
         
         # SetMenu 생성
         set_menu = SetMenu.objects.create(booth=booth, **validated_data)
@@ -77,7 +77,7 @@ class SetMenuService:
     @transaction.atomic
     def update_set_menu(set_menu, validated_data):
         """세트메뉴 수정 (이미지 삭제 포함)"""
-        set_items_data = validated_data.pop('set_items', None)
+        set_items_data = validated_data.pop('set_items_input', None)
         
         # 이미지 삭제 처리
         image_delete = validated_data.pop('image_delete', False)

--- a/django/menu/views.py
+++ b/django/menu/views.py
@@ -102,7 +102,7 @@ class SetMenuAPIView(APIView):
             for key in request.data:
                 if key == 'set_items':
                     try:
-                        data['set_items'] = json.loads(request.data.get('set_items'))
+                        data['set_items_input'] = json.loads(request.data.get('set_items'))
                     except json.JSONDecodeError:
                         return Response({
                             "message": "입력값 유효성 검사 실패",
@@ -161,7 +161,7 @@ class SetMenuDetailAPIView(APIView):
             for key in request.data:
                 if key == 'set_items':
                     try:
-                        data['set_items'] = json.loads(request.data.get('set_items'))
+                        data['set_items_input'] = json.loads(request.data.get('set_items'))
                     except json.JSONDecodeError:
                         return Response({
                             "message": "데이터 수정 형식이 올바르지 않습니다.",


### PR DESCRIPTION
- set_items_input: 입력용 필드 (write_only)
- set_items: 출력용 필드 (read_only) - menu_id, quantity, base_price, stock 포함
- views, services, serializers 모두 수정
- 프론트엔드는 동일하게 set_items로 요청/응답
- 모든 56개 테스트 통과

<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->


## 📍 PR Point

<!-- 나 이 부분 찢었다~! -->

## 📢 Notices

 <!-- 공용으로 사용하는(Extension) 부분에 대한 설명 -->

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #
<!-- - ex) #3 -->