### PR TITLE
fix: SetMenu serializer set_items 필드 충돌 수정

### DIFF
--- a/django/menu/serializers.py
+++ b/django/menu/serializers.py
@@ -225,7 +225,7 @@ class SetMenuSerializer(serializers.ModelSerializer):
             'required': '가격은 필수 항목입니다.',
         }
     )
-    set_items_input = serializers.ListField(
+    set_items = serializers.ListField(
         child=serializers.DictField(),
         write_only=True,
         error_messages={
@@ -244,7 +244,6 @@ class SetMenuSerializer(serializers.ModelSerializer):
     # 출력 필드
     set_id = serializers.IntegerField(source='id', read_only=True)
     booth_id = serializers.IntegerField(source='booth.pk', read_only=True)
-    set_items = SetMenuItemOutputSerializer(source='items', many=True, read_only=True)
     origin_price = serializers.SerializerMethodField()
     is_soldout = serializers.SerializerMethodField()
     
@@ -252,7 +251,7 @@ class SetMenuSerializer(serializers.ModelSerializer):
         model = SetMenu
         fields = [
             'set_id', 'booth_id', 'name', 'category', 'description',
-            'price', 'image', 'set_items_input', 'set_items',
+            'price', 'image', 'set_items',
             'origin_price', 'is_soldout', 'created_at', 'updated_at'
         ]
         read_only_fields = ['set_id', 'booth_id', 'category', 'created_at', 'updated_at']
@@ -271,7 +270,7 @@ class SetMenuSerializer(serializers.ModelSerializer):
                 return True
         return False
     
-    def validate_set_items_input(self, value):
+    def validate_set_items(self, value):
         """세트 구성 항목 유효성 검사"""
         # 빈 배열 체크
         if not value or len(value) == 0:
@@ -290,6 +289,14 @@ class SetMenuSerializer(serializers.ModelSerializer):
             validated_items.append(item_serializer.validated_data)
         
         return validated_items
+    
+    def to_representation(self, instance):
+        """출력 시 set_items을 SetMenuItemOutputSerializer로 처리"""
+        ret = super().to_representation(instance)
+        # set_items 필드가 없으면 items을 SetMenuItemOutputSerializer로 처리
+        if 'set_items' not in ret:
+            ret['set_items'] = SetMenuItemOutputSerializer(instance.items.all(), many=True).data
+        return ret
 
 
 class SetMenuUpdateSerializer(serializers.ModelSerializer):
@@ -323,7 +330,7 @@ class SetMenuUpdateSerializer(serializers.ModelSerializer):
             'invalid': '가격은 정수여야 합니다.',
         }
     )
-    set_items_input = serializers.ListField(
+    set_items = serializers.ListField(
         child=serializers.DictField(),
         required=False,
         error_messages={
@@ -339,7 +346,6 @@ class SetMenuUpdateSerializer(serializers.ModelSerializer):
     # 출력 필드
     set_id = serializers.IntegerField(source='id', read_only=True)
     booth_id = serializers.IntegerField(source='booth.pk', read_only=True)
-    set_items = SetMenuItemOutputSerializer(source='items', many=True, read_only=True)
     origin_price = serializers.SerializerMethodField()
     is_soldout = serializers.SerializerMethodField()
     
@@ -347,7 +353,7 @@ class SetMenuUpdateSerializer(serializers.ModelSerializer):
         model = SetMenu
         fields = [
             'set_id', 'booth_id', 'name', 'category', 'description',
-            'price', 'image', 'image_delete', 'set_items_input', 'set_items',
+            'price', 'image', 'image_delete', 'set_items',
             'origin_price', 'is_soldout', 'created_at', 'updated_at'
         ]
         read_only_fields = ['set_id', 'booth_id', 'category', 'image', 'created_at', 'updated_at']
@@ -366,7 +372,7 @@ class SetMenuUpdateSerializer(serializers.ModelSerializer):
                 return True
         return False
     
-    def validate_set_items_input(self, value):
+    def validate_set_items(self, value):
         """세트 구성 항목 유효성 검사"""
         # 빈 배열 체크 (수정 시에도 최소 1개 필요)
         if not value or len(value) == 0:
@@ -395,3 +401,11 @@ class SetMenuUpdateSerializer(serializers.ModelSerializer):
                     'image': '이미지는 수정할 수 없습니다. image_delete로 삭제만 가능합니다.'
                 })
         return attrs
+    
+    def to_representation(self, instance):
+        """출력 시 set_items을 SetMenuItemOutputSerializer로 처리"""
+        ret = super().to_representation(instance)
+        # set_items 필드가 없으면 items을 SetMenuItemOutputSerializer로 처리
+        if 'set_items' not in ret:
+            ret['set_items'] = SetMenuItemOutputSerializer(instance.items.all(), many=True).data
+        return ret

--- a/django/menu/services.py
+++ b/django/menu/services.py
@@ -58,7 +58,7 @@ class SetMenuService:
         세트메뉴 생성
         - SetMenu + SetMenuItem 함께 생성
         """
-        set_items_data = validated_data.pop('set_items_input')
+        set_items_data = validated_data.pop('set_items')
         
         # SetMenu 생성
         set_menu = SetMenu.objects.create(booth=booth, **validated_data)
@@ -77,7 +77,7 @@ class SetMenuService:
     @transaction.atomic
     def update_set_menu(set_menu, validated_data):
         """세트메뉴 수정 (이미지 삭제 포함)"""
-        set_items_data = validated_data.pop('set_items_input', None)
+        set_items_data = validated_data.pop('set_items', None)
         
         # 이미지 삭제 처리
         image_delete = validated_data.pop('image_delete', False)

--- a/django/menu/views.py
+++ b/django/menu/views.py
@@ -102,7 +102,7 @@ class SetMenuAPIView(APIView):
             for key in request.data:
                 if key == 'set_items':
                     try:
-                        data['set_items_input'] = json.loads(request.data.get('set_items'))
+                        data['set_items'] = json.loads(request.data.get('set_items'))
                     except json.JSONDecodeError:
                         return Response({
                             "message": "입력값 유효성 검사 실패",
@@ -161,7 +161,7 @@ class SetMenuDetailAPIView(APIView):
             for key in request.data:
                 if key == 'set_items':
                     try:
-                        data['set_items_input'] = json.loads(request.data.get('set_items'))
+                        data['set_items'] = json.loads(request.data.get('set_items'))
                     except json.JSONDecodeError:
                         return Response({
                             "message": "데이터 수정 형식이 올바르지 않습니다.",


### PR DESCRIPTION
- set_items를 입력/출력으로 동시에 사용할 수 없는 DRF 제한 우회
- to_representation 메서드를 통해 출력 시 SetMenuItemOutputSerializer 적용
- SetMenuSerializer, SetMenuUpdateSerializer 모두 적용
- 입력: JSON 배열로 set_items 수렴 (write_only)
- 출력: to_representation에서 menu_id, quantity, base_price, stock 포함 변환
- 모든 56개 menu 테스트 통과 확인

<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->


## 📍 PR Point

<!-- 나 이 부분 찢었다~! -->

## 📢 Notices

 <!-- 공용으로 사용하는(Extension) 부분에 대한 설명 -->

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #
<!-- - ex) #3 -->