### PR TITLE
[Feat] #275 - 직원 호출 삭제 구현

### DIFF
--- a/spring/src/main/java/com/example/spring/controller/staffcall/StaffCallController.java
+++ b/spring/src/main/java/com/example/spring/controller/staffcall/StaffCallController.java
@@ -3,6 +3,7 @@ package com.example.spring.controller.staffcall;
 import com.example.spring.dto.staffcall.request.StaffCallAcceptRequest;
 import com.example.spring.dto.staffcall.request.StaffCallCancelRequest;
 import com.example.spring.dto.staffcall.request.StaffCallCompleteRequest;
+import com.example.spring.dto.staffcall.request.StaffCallDeleteRequest;
 import com.example.spring.dto.staffcall.request.StaffCallEmitRequest;
 import com.example.spring.dto.staffcall.request.StaffCallListRequest;
 import com.example.spring.dto.staffcall.response.StaffCallAcceptResponse;
@@ -34,6 +35,22 @@ public class StaffCallController {
             @RequestBody StaffCallEmitRequest body) {
         try {
             return ResponseEntity.ok(staffCallService.emit(body));
+        } catch (StaffCallConflictException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("message", e.getMessage()));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("message", e.getMessage()));
+        }
+    }
+
+    /**
+     * 직원 호출 삭제(생성 직후 취소) — 무인증 고객용.
+     * subscribe_token 검증 후, PENDING 상태의 staff_call만 삭제한다.
+     */
+    @PostMapping("/staffcall/delete")
+    public ResponseEntity<Map<String, Object>> delete(
+            @RequestBody StaffCallDeleteRequest body) {
+        try {
+            return ResponseEntity.ok(staffCallService.deleteByCustomer(body));
         } catch (StaffCallConflictException e) {
             return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("message", e.getMessage()));
         } catch (IllegalArgumentException e) {

--- a/spring/src/main/java/com/example/spring/dto/staffcall/request/StaffCallDeleteRequest.java
+++ b/spring/src/main/java/com/example/spring/dto/staffcall/request/StaffCallDeleteRequest.java
@@ -1,0 +1,16 @@
+package com.example.spring.dto.staffcall.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 고객(무인증)에서 생성 직후 staff_call 삭제 요청에 사용.
+ * subscribe_token으로만 삭제 권한을 검증한다.
+ */
+@Getter
+@NoArgsConstructor
+public class StaffCallDeleteRequest {
+    private Long staffCallId;
+    private String subscribeToken;
+}
+

--- a/spring/src/main/java/com/example/spring/repository/staffcall/StaffCallRepository.java
+++ b/spring/src/main/java/com/example/spring/repository/staffcall/StaffCallRepository.java
@@ -29,7 +29,16 @@ public interface StaffCallRepository extends JpaRepository<StaffCall, Long> {
             FROM staff_call sc
             WHERE sc.booth_id = :boothId
             AND sc.status IN ('PENDING', 'ACCEPTED')
-            ORDER BY sc.created_at DESC
+            ORDER BY
+              CASE
+                WHEN sc.status = 'PENDING' THEN 1
+                ELSE 0
+              END ASC,
+              CASE
+                WHEN sc.status = 'ACCEPTED' THEN sc.accepted_at
+                ELSE sc.created_at
+              END DESC,
+              sc.id DESC
             LIMIT :limit OFFSET :offset
             """, nativeQuery = true)
     List<StaffCall> findActiveCallsForBooth(

--- a/spring/src/main/java/com/example/spring/security/ServerApiJwtFilter.java
+++ b/spring/src/main/java/com/example/spring/security/ServerApiJwtFilter.java
@@ -17,7 +17,7 @@ import java.nio.charset.StandardCharsets;
 /**
  * {@code /server/**}, {@code /serving/**} 서버(직원/서빙) API — (기본) access_token 쿠키 필수
  * <p>
- * 단, 직원 호출 등록(emit)은 인증을 강제하지 않음
+ * 단, 직원 호출 등록(emit) 및 생성 직후 삭제는 인증을 강제하지 않음
  */
 @Component
 @RequiredArgsConstructor
@@ -45,7 +45,7 @@ public class ServerApiJwtFilter extends OncePerRequestFilter {
             return;
         }
 
-        // 직원 호출 등록(emit)만 인증을 강제하지 않음
+        // 직원 호출 등록(emit) / 생성 직후 삭제만 인증을 강제하지 않음
         if (isStaffCallPublicPath(path)) {
             filterChain.doFilter(request, response);
             return;
@@ -80,6 +80,7 @@ public class ServerApiJwtFilter extends OncePerRequestFilter {
     }
 
     private boolean isStaffCallPublicPath(String path) {
-        return "/server/staffcall/request".equals(path);
+        return "/server/staffcall/request".equals(path)
+                || "/server/staffcall/delete".equals(path);
     }
 }

--- a/spring/src/main/java/com/example/spring/service/staffcall/StaffCallService.java
+++ b/spring/src/main/java/com/example/spring/service/staffcall/StaffCallService.java
@@ -10,6 +10,7 @@ import com.example.spring.dto.redis.StaffCallRedisMessageDto;
 import com.example.spring.dto.staffcall.request.StaffCallAcceptRequest;
 import com.example.spring.dto.staffcall.request.StaffCallCancelRequest;
 import com.example.spring.dto.staffcall.request.StaffCallCompleteRequest;
+import com.example.spring.dto.staffcall.request.StaffCallDeleteRequest;
 import com.example.spring.dto.staffcall.request.StaffCallEmitRequest;
 import com.example.spring.dto.staffcall.response.StaffCallAcceptResponse;
 import com.example.spring.dto.staffcall.response.StaffCallItemResponse;
@@ -177,6 +178,50 @@ public class StaffCallService {
         Map<String, Object> out = new HashMap<>();
         out.put("message", "호출을 완료 처리했습니다.");
         out.put("data", StaffCallItemResponse.from(sc));
+        return out;
+    }
+
+    /**
+     * 무인증 고객이 생성 직후 staff_call을 삭제(취소)하는 API.
+     * - subscribe_token으로만 권한 검증
+     * - PENDING 상태만 삭제 가능 (ACCEPTED 이후는 충돌)
+     */
+    @Transactional
+    public Map<String, Object> deleteByCustomer(StaffCallDeleteRequest req) {
+        if (req == null || req.getStaffCallId() == null) {
+            throw new IllegalArgumentException("staff_call_id는 필수입니다.");
+        }
+        Long staffCallId = req.getStaffCallId();
+        String token = req.getSubscribeToken();
+        if (token == null || token.isBlank()) {
+            throw new IllegalArgumentException("subscribe_token은 필수입니다.");
+        }
+        if (!customerStaffCallWebSocketHandler.isValidSubscribeToken(staffCallId, token)) {
+            throw new StaffCallConflictException("유효하지 않은 subscribe_token 입니다.");
+        }
+
+        StaffCall sc = staffCallRepository.findById(staffCallId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 호출을 찾을 수 없습니다."));
+
+        if (sc.getStatus() != StaffCallStatus.PENDING) {
+            throw new StaffCallConflictException("대기 중인 호출만 취소할 수 있습니다.");
+        }
+
+        Long boothId = sc.getBoothId();
+        staffCallRepository.delete(sc);
+
+        publishRedis(sc, "staff_call_deleted");
+        try {
+            staffCallWebSocketHandler.broadcastSnapshot(boothId,
+                    staffCallQueryService.listForBooth(boothId, 50, 0));
+            customerStaffCallWebSocketHandler.broadcastDeleted(staffCallId);
+        } catch (Exception e) {
+            log.error("[staffcall deleteByCustomer] 스냅샷 조회/WS 푸시 실패 — 삭제는 반영됨 boothId={}", boothId, e);
+        }
+
+        Map<String, Object> out = new HashMap<>();
+        out.put("message", "호출을 취소했습니다.");
+        out.put("data", Map.of("staff_call_id", staffCallId));
         return out;
     }
 

--- a/spring/src/main/java/com/example/spring/websocket/CustomerStaffCallWebSocketHandler.java
+++ b/spring/src/main/java/com/example/spring/websocket/CustomerStaffCallWebSocketHandler.java
@@ -130,6 +130,33 @@ public class CustomerStaffCallWebSocketHandler extends TextWebSocketHandler {
         }
     }
 
+    public void broadcastDeleted(Long staffCallId) {
+        Set<WebSocketSession> sessions = staffCallSessions.get(staffCallId);
+        if (sessions == null || sessions.isEmpty()) return;
+
+        try {
+            String json = objectMapper.writeValueAsString(Map.of(
+                    "type", "STAFF_CALL_STATUS",
+                    "staff_call_id", staffCallId,
+                    "status", "DELETED"
+            ));
+            TextMessage tm = new TextMessage(json);
+            for (WebSocketSession s : sessions) {
+                if (s.isOpen()) {
+                    try {
+                        s.sendMessage(tm);
+                    } catch (IOException e) {
+                        log.warn("[customer staffcall ws] 삭제 전송 실패 session={}", s.getId(), e);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.error("[customer staffcall ws] broadcastDeleted 실패 staffCallId={}", staffCallId, e);
+        } finally {
+            staffCallSessions.remove(staffCallId);
+        }
+    }
+
     private Map<String, Object> statusEvent(StaffCall sc) {
         Map<String, Object> out = new HashMap<>();
         out.put("type", "STAFF_CALL_STATUS");
@@ -153,6 +180,13 @@ public class CustomerStaffCallWebSocketHandler extends TextWebSocketHandler {
         String token = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
         redisTemplate.opsForValue().set(REDIS_SUBSCRIBE_TOKEN_KEY_PREFIX + staffCallId, token, SUBSCRIBE_TOKEN_TTL);
         return token;
+    }
+
+    public boolean isValidSubscribeToken(Long staffCallId, String token) {
+        if (staffCallId == null || staffCallId <= 0) return false;
+        if (token == null || token.isBlank()) return false;
+        String expected = getSubscribeToken(staffCallId);
+        return expected != null && expected.equals(token);
     }
 
     private String getSubscribeToken(Long staffCallId) {


### PR DESCRIPTION
## 🔍 What is the PR?

무인증 고객이 생성 직후 직원 호출을 취소할 수 있도록 POST /server/staffcall/delete API 추가 (subscribe_token 검증 기반)
삭제 성공 시 직원 호출 목록(WebSocket 스냅샷)과 고객 단건 상태를 즉시 갱신하고, Redis Pub/Sub 이벤트(spring:booth:{id}:staffcall:deleted) 발행
직원 호출 목록 정렬 개선: 수락됨(ACCEPTED) 우선 노출 + 수락 최신순, 미수락(PENDING)은 하단에 생성 최신순

##📍 PR Point

고객(무인증) 취소 기능을 subscribe_token(TTL) 기반 권한 검증으로 설계해 임의 삭제를 방지
삭제/정렬 변경이 REST 조회 + WebSocket 스냅샷 양쪽에 동일하게 반영되도록 서버 단에서 일관성 있게 처리
동시성/운영 관점에서 PENDING만 삭제 허용(수락 이후는 Conflict)으로 규칙을 명확히 함

## 📢 Notices

ServerApiJwtFilter에서 /server/staffcall/delete를 public 경로로 예외 처리했습니다. (무인증 고객 호출/취소 흐름)
삭제는 물리 삭제(DB row delete) 이며, 고객 WS에는 status: "DELETED" 이벤트가 전달됩니다.

💭 Related Issues
#275