### PR TITLE
[Fix] #275 - 직원 호출 목록 정렬 우선순위 수정

### DIFF
--- a/spring/src/main/java/com/example/spring/repository/staffcall/StaffCallRepository.java
+++ b/spring/src/main/java/com/example/spring/repository/staffcall/StaffCallRepository.java
@@ -31,8 +31,8 @@ public interface StaffCallRepository extends JpaRepository<StaffCall, Long> {
             AND sc.status IN ('PENDING', 'ACCEPTED')
             ORDER BY
               CASE
-                WHEN sc.status = 'PENDING' THEN 1
-                ELSE 0
+                WHEN sc.status = 'PENDING' THEN 0
+                ELSE 1
               END ASC,
               CASE
                 WHEN sc.status = 'ACCEPTED' THEN sc.accepted_at


### PR DESCRIPTION
PENDING을 상단에 노출하고, ACCEPTED를 하단에 배치하도록 정렬 그룹 우선순위를 반전합니다.

#275