### PR TITLE
feat: 운영자 메뉴 조회 응답에 세트메뉴 set_items 추가

### DIFF
--- a/django/menu/serializers.py
+++ b/django/menu/serializers.py
@@ -244,6 +244,7 @@ class SetMenuSerializer(serializers.ModelSerializer):
     # 출력 필드
     set_id = serializers.IntegerField(source='id', read_only=True)
     booth_id = serializers.IntegerField(source='booth.pk', read_only=True)
+    set_items_output = SetMenuItemOutputSerializer(source='items', many=True, read_only=True)
     origin_price = serializers.SerializerMethodField()
     is_soldout = serializers.SerializerMethodField()
     
@@ -251,7 +252,7 @@ class SetMenuSerializer(serializers.ModelSerializer):
         model = SetMenu
         fields = [
             'set_id', 'booth_id', 'name', 'category', 'description',
-            'price', 'image', 'set_items',
+            'price', 'image', 'set_items', 'set_items_output',
             'origin_price', 'is_soldout', 'created_at', 'updated_at'
         ]
         read_only_fields = ['set_id', 'booth_id', 'category', 'created_at', 'updated_at']
@@ -291,11 +292,10 @@ class SetMenuSerializer(serializers.ModelSerializer):
         return validated_items
     
     def to_representation(self, instance):
-        """출력 시 set_items을 SetMenuItemOutputSerializer로 처리"""
+        """출력 시 set_items_output을 set_items로 변환"""
         ret = super().to_representation(instance)
-        # set_items 필드가 없으면 items을 SetMenuItemOutputSerializer로 처리
-        if 'set_items' not in ret:
-            ret['set_items'] = SetMenuItemOutputSerializer(instance.items.all(), many=True).data
+        if 'set_items_output' in ret:
+            ret['set_items'] = ret.pop('set_items_output')
         return ret
 
 
@@ -346,6 +346,7 @@ class SetMenuUpdateSerializer(serializers.ModelSerializer):
     # 출력 필드
     set_id = serializers.IntegerField(source='id', read_only=True)
     booth_id = serializers.IntegerField(source='booth.pk', read_only=True)
+    set_items_output = SetMenuItemOutputSerializer(source='items', many=True, read_only=True)
     origin_price = serializers.SerializerMethodField()
     is_soldout = serializers.SerializerMethodField()
     
@@ -353,7 +354,7 @@ class SetMenuUpdateSerializer(serializers.ModelSerializer):
         model = SetMenu
         fields = [
             'set_id', 'booth_id', 'name', 'category', 'description',
-            'price', 'image', 'image_delete', 'set_items',
+            'price', 'image', 'image_delete', 'set_items', 'set_items_output',
             'origin_price', 'is_soldout', 'created_at', 'updated_at'
         ]
         read_only_fields = ['set_id', 'booth_id', 'category', 'image', 'created_at', 'updated_at']
@@ -403,9 +404,8 @@ class SetMenuUpdateSerializer(serializers.ModelSerializer):
         return attrs
     
     def to_representation(self, instance):
-        """출력 시 set_items을 SetMenuItemOutputSerializer로 처리"""
+        """출력 시 set_items_output을 set_items로 변환"""
         ret = super().to_representation(instance)
-        # set_items 필드가 없으면 items을 SetMenuItemOutputSerializer로 처리
-        if 'set_items' not in ret:
-            ret['set_items'] = SetMenuItemOutputSerializer(instance.items.all(), many=True).data
+        if 'set_items_output' in ret:
+            ret['set_items'] = ret.pop('set_items_output')
         return ret

--- a/django/menu/views.py
+++ b/django/menu/views.py
@@ -250,6 +250,17 @@ class BoothMenuListAPIView(APIView):
             item_stocks = [item.menu.stock // item.quantity for item in setmenu.items.all() if item.menu.stock is not None and item.quantity > 0]
             min_stock = min(item_stocks) if item_stocks else 0
             is_soldout = any(item.menu.stock == 0 for item in setmenu.items.all())
+            
+            # set_items 구성
+            set_items = []
+            for item in setmenu.items.all():
+                set_items.append({
+                    "menu_id": item.menu.pk,
+                    "quantity": item.quantity,
+                    "base_price": int(item.menu.price),
+                    "stock": item.menu.stock
+                })
+            
             data.append({
                 "id": setmenu.pk,
                 "name": setmenu.name,
@@ -260,7 +271,8 @@ class BoothMenuListAPIView(APIView):
                 "stock": min_stock,
                 "is_soldout": is_soldout,
                 "is_fixed": False,
-                "created_at": setmenu.created_at.isoformat() if hasattr(setmenu, 'created_at') else None
+                "created_at": setmenu.created_at.isoformat() if hasattr(setmenu, 'created_at') else None,
+                "set_items": set_items
             })
         return Response({
             "message": "운영자 메뉴 목록 조회 완료",


### PR DESCRIPTION


<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->
- GET /api/v3/django/booth/menus/ 응답에서 SET 카테고리 항목에 set_items 필드 추가
- set_items: [{ menu_id, quantity, base_price, stock }, ...]
- 각 구성품의 재고(stock)를 개별로 반환하여 프론트에서 품절 판단 가능
- 모든 56개 menu 테스트 통과

## 📍 PR Point

<!-- 나 이 부분 찢었다~! -->

## 📢 Notices

 <!-- 공용으로 사용하는(Extension) 부분에 대한 설명 -->

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #
<!-- - ex) #3 -->