### PR TITLE
fix: 서빙 취소 시 SERVING 상태도 처리하도록 수정

### DIFF
--- a/django/order/services.py
+++ b/django/order/services.py
@@ -1015,16 +1015,16 @@ class OrderService:
             logger.warning(f"[ServingCancelled] 세트메뉴 부모 아이템 롤백 시도: id={order_item_id}")
             return {"result": "invalid_target"}
 
-        # SERVED 상태에서만 롤백 가능
-        if item.status != "SERVED":
-            logger.warning(f"[ServingCancelled] 이미 SERVED 상태 아님: id={order_item_id}, current_status={item.status}")
+        # SERVING 또는 SERVED 상태에서만 롤백 가능
+        if item.status not in ("SERVING", "SERVED"):
+            logger.warning(f"[ServingCancelled] 이미 SERVING/SERVED 상태 아님: id={order_item_id}, current_status={item.status}")
             return {"result": "invalid_status"}
 
         old_status = item.status
         now = timezone.now()
         reason = event_data.get("reason", "Robot error")
 
-        # 상태 변경: SERVED → COOKED (served_at 유지)
+        # 상태 변경 (SERVING → COOKED 또는 SERVED → COOKED)
         item.status = "COOKED"
         item.save(update_fields=["status"])
 


### PR DESCRIPTION
- 기존: SERVED 상태만 COOKED로 롤백
- 수정: SERVING, SERVED 상태 모두 COOKED로 롤백
- ServingTask 뒤로가기(서빙 수락 취소) 시 SERVING → COOKED 상태 변경

<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->


## 📍 PR Point

<!-- 나 이 부분 찢었다~! -->

## 📢 Notices

 <!-- 공용으로 사용하는(Extension) 부분에 대한 설명 -->

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #278
<!-- - ex) #3 -->