### PR TITLE
🔧 [chore] #283 - 웹소켓 콘피그 로컬호스트  https경로 허용

### DIFF
--- a/spring/src/main/java/com/example/spring/config/WebSocketConfig.java
+++ b/spring/src/main/java/com/example/spring/config/WebSocketConfig.java
@@ -25,7 +25,9 @@ public class WebSocketConfig implements WebSocketConfigurer {
         registry.addHandler(servingWebSocketHandler, "/ws/serving")
                 .setAllowedOriginPatterns(
                         "http://localhost:5173",
+                        "https://localhost:5173",
                         "http://localhost:5174",
+                        "https://localhost:5174",
                         "https://dev.dorder-api.shop",
                         "http://dev.dorder-api.shop",
                         "https://*.dorder-api.shop"


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->
fe어드민에서 스프링부트 웹소켓 연결할때 로컬호스트 https경로가   허용이 안돼있어 연결이 안되는 문제가 있었음. 이를 위해 로컬호스트 https경로도 허용 

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #283 
<!-- - ex) #3 -->