### PR TITLE
[fix]: 메뉴 집계에서 세트메뉴 자식 상태 검증 추가

### DIFF
--- a/django/order/consumers.py
+++ b/django/order/consumers.py
@@ -266,15 +266,18 @@ class AdminOrderManagementConsumer(KoreanAsyncJsonMixin, AsyncJsonWebsocketConsu
             for item in qs:
                 # 세트메뉴 또는 일반 메뉴 이름 결정
                 if item.setmenu_id:
-                    name = item.setmenu.name
-                    # 세트메뉴는 카테고리 없음 → food_map에 추가
-                    target = food_map
+                    # 세트메뉴: 모든 자식이 COOKING 상태인 경우만 포함
+                    children = item.children.all()
+                    if children.exists() and all(child.status == "COOKING" for child in children):
+                        name = item.setmenu.name
+                        # 세트메뉴는 카테고리 없음 → food_map에 추가
+                        target = food_map
+                        target[name] = target.get(name, 0) + item.quantity
                 else:
                     name = item.menu.name
                     category = item.menu.category
                     target = drink_map if category == "DRINK" else food_map
-                
-                target[name] = target.get(name, 0) + item.quantity
+                    target[name] = target.get(name, 0) + item.quantity
 
             def sort_key(pair):
                 return (-pair[1], pair[0])

--- a/django/order/services.py
+++ b/django/order/services.py
@@ -95,6 +95,30 @@ class OrderService:
 
         table_num = order.table_usage.table.table_num
 
+        # ─── COOKING → Redis 발행 (서빙 요청 취소) ───
+        # 조리중으로 다시 변경되었을 때 (COOKED → COOKING), Spring의 ServingTask 제거
+        if target_status == "COOKING" and old_status == "COOKED":
+            try:
+                from core.redis_client import publish
+                publish(
+                    f"booth:{booth_id}:order:cooking",
+                    {
+                        "event": "SERVING_CANCELLED",
+                        "order_item_id": order_item_id,
+                        "table_num": table_num,
+                        "menu_name": menu_name,
+                        "quantity": item.quantity,
+                        "reason": "조리 다시 시작",
+                        "timestamp": timezone.localtime(now).isoformat(),
+                    }
+                )
+                logger.info(
+                    f"[ServingTask 취소] order_item_id={order_item_id}, "
+                    f"테이블={table_num}, 메뉴={menu_name}"
+                )
+            except Exception as e:
+                logger.error(f"[OrderItem] Redis 발행 실패 (COOKING): {e}")
+
         # ─── COOKED → Redis 발행 (스프링부트 서빙 알림) ───
         if target_status == "COOKED":
             try:


### PR DESCRIPTION

<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->
- 세트메뉴가 COOKED 상태일 때도 집계에 나타나는 버그 수정
- 세트메뉴 모든 자식이 COOKING 상태일 때만 집계에 포함
- 부분적으로 조리 완료된 세트메뉴는 집계에서 제외


## 📍 PR Point

<!-- 나 이 부분 찢었다~! -->

## 📢 Notices

 <!-- 공용으로 사용하는(Extension) 부분에 대한 설명 -->

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #
<!-- - ex) #3 -->