### PR TITLE
fix: 세트메뉴 구성품 이미지를 세트메뉴 이미지로 표시

### DIFF
--- a/django/order/consumers.py
+++ b/django/order/consumers.py
@@ -243,41 +243,30 @@ class AdminOrderManagementConsumer(KoreanAsyncJsonMixin, AsyncJsonWebsocketConsu
         active_statuses = ["COOKING"]  # 조리중인 것만
 
         def _query():
-            # 조리 중인 주문 아이템 조회
-            # - 일반 메뉴 (menu≠NULL, parent=NULL)
-            # - 세트메뉴 부모 (setmenu≠NULL, menu=NULL, parent=NULL)
-            # - 세트메뉴 구성품은 자동으로 포함됨
-            # - FEE 카테고리는 제외 (테이블 이용료 제외)
+            # 리프 아이템만 집계: 메뉴가 있는 아이템들 (세트메뉴 부모 제외, 자식 + 일반 메뉴)
+            # FEE 카테고리는 제외 (테이블 이용료는 메뉴 집계에서 제외)
             qs = (
                 OrderItem.objects
                 .filter(
                     order__order_status="PAID",
                     order__table_usage__table__booth_id=self.booth_id,
                     status__in=active_statuses,
-                    parent__isnull=True,  # 세트메뉴 자식 제외
+                    menu__isnull=False,
                 )
+                .exclude(parent__isnull=True, setmenu__isnull=False)  # 세트메뉴 부모 제외
                 .exclude(menu__category="FEE")
-                .select_related("menu", "setmenu")
+                .select_related("menu")
             )
 
             food_map = {}
             drink_map = {}
 
             for item in qs:
-                # 세트메뉴 또는 일반 메뉴 이름 결정
-                if item.setmenu_id:
-                    # 세트메뉴: 모든 자식이 COOKING 상태인 경우만 포함
-                    children = item.children.all()
-                    if children.exists() and all(child.status == "COOKING" for child in children):
-                        name = item.setmenu.name
-                        # 세트메뉴는 카테고리 없음 → food_map에 추가
-                        target = food_map
-                        target[name] = target.get(name, 0) + item.quantity
-                else:
-                    name = item.menu.name
-                    category = item.menu.category
-                    target = drink_map if category == "DRINK" else food_map
-                    target[name] = target.get(name, 0) + item.quantity
+                # 일반 메뉴 또는 세트메뉴 구성품의 메뉴 이름
+                name = item.menu.name
+                category = item.menu.category
+                target = drink_map if category == "DRINK" else food_map
+                target[name] = target.get(name, 0) + item.quantity
 
             def sort_key(pair):
                 return (-pair[1], pair[0])
@@ -400,13 +389,13 @@ class AdminOrderManagementConsumer(KoreanAsyncJsonMixin, AsyncJsonWebsocketConsu
                 if item.setmenu_id:
                     # 세트메뉴 → 자식 OrderItem 개별 직렬화
                     set_menu_name = item.setmenu.name
+                    set_menu_image = item.setmenu.image.url if item.setmenu and item.setmenu.image else None
                     for child in item.children.all():
                         child_menu_name = child.menu.name if child.menu else "알 수 없음"
-                        image = child.menu.image.url if child.menu and child.menu.image else None
                         items.append({
                             "order_item_id": child.id,
-                            "menu_name": set_menu_name,
-                            "image": image,
+                            "menu_name": child_menu_name,
+                            "image": set_menu_image,
                             "quantity": child.quantity,
                             "fixed_price": item.fixed_price,
                             "item_total_price": item.fixed_price * item.quantity,


### PR DESCRIPTION
- 실시간 주문 페이지에서 구성품별로 세트메뉴의 이미지 표시
- child.menu.image → set_menu_image로 변경

<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->


## 📍 PR Point

<!-- 나 이 부분 찢었다~! -->

## 📢 Notices

 <!-- 공용으로 사용하는(Extension) 부분에 대한 설명 -->

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #
<!-- - ex) #3 -->