### PR TITLE
fix: 새주문 생성 시 메뉴 집계 갱신 추가

### DIFF
--- a/django/order/consumers.py
+++ b/django/order/consumers.py
@@ -527,7 +527,8 @@ class BoothSalesConsumer(KoreanAsyncJsonMixin, AsyncJsonWebsocketConsumer):
         pass
 
     async def admin_menu_aggregation(self, event):
-        pass
+        """메뉴 집계 갱신 핸들러"""
+        await self.send_menu_aggregation()
 
     async def _get_today_revenue(self):
         """오늘 매출 (캐시 우선, 미스 시 DB 초기화)"""

--- a/django/order/services.py
+++ b/django/order/services.py
@@ -184,6 +184,15 @@ class OrderService:
                     },
                 }
             )
+            
+            # 메뉴 집계 갱신
+            async_to_sync(channel_layer.group_send)(
+                group_name,
+                {
+                    "type": "admin_menu_aggregation",
+                    "data": {}
+                }
+            )
         except Exception as e:
             logger.error(f"[OrderItem] WebSocket ADMIN_ORDER_UPDATE 전송 실패: {e}")
 
@@ -582,6 +591,15 @@ class OrderService:
                     },
                 }
             )
+            
+            # 메뉴 집계 갱신
+            async_to_sync(channel_layer.group_send)(
+                group_name,
+                {
+                    "type": "admin_menu_aggregation",
+                    "data": {}
+                }
+            )
         except Exception as e:
             logger.error(f"[Serving] WebSocket ADMIN_ORDER_UPDATE 전송 실패: {e}")
 
@@ -772,6 +790,11 @@ class OrderService:
             async_to_sync(get_channel_layer().group_send)(
                 group_name,
                 {"type": "total_sales_update", "data": {"today_revenue": today_revenue}}
+            )
+            # 메뉴 집계 갱신
+            async_to_sync(get_channel_layer().group_send)(
+                group_name,
+                {"type": "admin_menu_aggregation", "data": {}}
             )
         except Exception as ws_err:
             logger.error(f"[Order] WebSocket 전송 실패 (주문은 정상 생성됨): {ws_err}")
@@ -1096,6 +1119,15 @@ class OrderService:
                         "order_id": order.pk,
                         "items": items_payload,
                     },
+                }
+            )
+            
+            # 메뉴 집계 갱신
+            async_to_sync(channel_layer.group_send)(
+                group_name,
+                {
+                    "type": "admin_menu_aggregation",
+                    "data": {}
                 }
             )
         except Exception as e:


### PR DESCRIPTION
- 새 주문 생성 후 WebSocket으로 메뉴 집계 갱신 메시지 전송
- 상태 변경 시뿐만 아니라 초기 생성 시에도 집계 업데이트
- 세트메뉴 자식 메뉴(피자, 콜라)가 집계에 바로 반영됨

<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->


## 📍 PR Point

<!-- 나 이 부분 찢었다~! -->

## 📢 Notices

 <!-- 공용으로 사용하는(Extension) 부분에 대한 설명 -->

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #
<!-- - ex) #3 -->