### PR TITLE
fix: 새주문 직후 메뉴집계 누락 레이스 수정

### DIFF
--- a/django/order/consumers.py
+++ b/django/order/consumers.py
@@ -148,6 +148,7 @@ class AdminOrderManagementConsumer(KoreanAsyncJsonMixin, AsyncJsonWebsocketConsu
                 "orders": [],
             },
         })
+        await self.send_menu_aggregation()
 
     # ───────────────────────────────────────────
     # ③ ADMIN_ORDER_UPDATE (group_send handler)
@@ -207,6 +208,12 @@ class AdminOrderManagementConsumer(KoreanAsyncJsonMixin, AsyncJsonWebsocketConsu
         음식(MENU) / 음료(DRINK)로 분류, 수량 내림차순 → 이름 오름차순.
         """
         aggregation = await self._get_menu_aggregation()
+        logger.warning(
+            "📊 [Order WS] MENU_AGGREGATION 전송 - booth_id=%s, food=%s, drink=%s",
+            self.booth_id,
+            len(aggregation.get("food_summary", [])),
+            len(aggregation.get("beverage_summary", [])),
+        )
         await self.send_json({
             "type": "MENU_AGGREGATION",
             "data": aggregation,
@@ -527,8 +534,8 @@ class BoothSalesConsumer(KoreanAsyncJsonMixin, AsyncJsonWebsocketConsumer):
         pass
 
     async def admin_menu_aggregation(self, event):
-        """메뉴 집계 갱신 핸들러"""
-        await self.send_menu_aggregation()
+        # BoothSalesConsumer는 메뉴 집계를 다루지 않음
+        pass
 
     async def _get_today_revenue(self):
         """오늘 매출 (캐시 우선, 미스 시 DB 초기화)"""

--- a/django/order/services.py
+++ b/django/order/services.py
@@ -760,44 +760,52 @@ class OrderService:
         )
 
         # ⑨ WebSocket 브로드캐스트
+        booth_id = table_usage.table.booth_id
         try:
             from channels.layers import get_channel_layer
             from asgiref.sync import async_to_sync
             from order.cache import update_today_revenue
 
-            booth_id = table_usage.table.booth_id
             # order.order_price를 int로 변환 (Decimal → int)
             order_price_int = int(order.order_price)
             today_revenue = update_today_revenue(booth_id, order_price_int)
-
             group_name = f"booth_{booth_id}.order"
-            async_to_sync(get_channel_layer().group_send)(
-                group_name,
-                {
-                    "type": "admin_new_order",
-                    "data": {
-                        "order_id": order.pk,
-                        "cart_id": cart_id,
-                        "table_usage_id": table_usage_id,
-                        "order_price": order_price_int,
-                        "original_price": int(order.original_price) if order.original_price else 0,
-                        "total_discount": int(order.total_discount) if order.total_discount else 0,
-                        "order_status": order.order_status,
-                    }
-                }
-            )
-            # 오늘 매출 갱신 이벤트 (계산된 값 포함 → Consumer DB 쿼리 불필요)
-            async_to_sync(get_channel_layer().group_send)(
-                group_name,
-                {"type": "total_sales_update", "data": {"today_revenue": today_revenue}}
-            )
-            # 메뉴 집계 갱신
-            async_to_sync(get_channel_layer().group_send)(
-                group_name,
-                {"type": "admin_menu_aggregation", "data": {}}
-            )
+            channel_layer = get_channel_layer()
+
+            # 트랜잭션 커밋 이후 전송해야 consumer 조회 시 최신 데이터가 보장됨
+            def _send_ws_events_after_commit():
+                try:
+                    async_to_sync(channel_layer.group_send)(
+                        group_name,
+                        {
+                            "type": "admin_new_order",
+                            "data": {
+                                "order_id": order.pk,
+                                "cart_id": cart_id,
+                                "table_usage_id": table_usage_id,
+                                "order_price": order_price_int,
+                                "original_price": int(order.original_price) if order.original_price else 0,
+                                "total_discount": int(order.total_discount) if order.total_discount else 0,
+                                "order_status": order.order_status,
+                            }
+                        }
+                    )
+                    # 오늘 매출 갱신 이벤트 (계산된 값 포함 → Consumer DB 쿼리 불필요)
+                    async_to_sync(channel_layer.group_send)(
+                        group_name,
+                        {"type": "total_sales_update", "data": {"today_revenue": today_revenue}}
+                    )
+                    # 메뉴 집계 갱신
+                    async_to_sync(channel_layer.group_send)(
+                        group_name,
+                        {"type": "admin_menu_aggregation", "data": {}}
+                    )
+                except Exception as ws_err:
+                    logger.error(f"[Order] WebSocket 전송 실패 (주문은 정상 생성됨): {ws_err}")
+
+            transaction.on_commit(_send_ws_events_after_commit)
         except Exception as ws_err:
-            logger.error(f"[Order] WebSocket 전송 실패 (주문은 정상 생성됨): {ws_err}")
+            logger.error(f"[Order] WebSocket 준비 실패 (주문은 정상 생성됨): {ws_err}")
 
         # ⑩ 테이블 WebSocket 브로드캐스트
         try:


### PR DESCRIPTION
- create_order_from_event의 WS 전송을 transaction.on_commit으로 지연
- ADMIN_NEW_ORDER fallback 경로에서도 MENU_AGGREGATION 전송
- BoothSalesConsumer의 잘못된 admin_menu_aggregation 핸들러 제거
- 메뉴 집계 전송 로그 추가(booth/food/drink count)

<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->


## 📍 PR Point

<!-- 나 이 부분 찢었다~! -->

## 📢 Notices

 <!-- 공용으로 사용하는(Extension) 부분에 대한 설명 -->

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #
<!-- - ex) #3 -->