### PR TITLE
✨ [Feat] : 서빙 요청 멱등성 redis 구독 추가 및 tableNumber 기반 동기화 추가

### DIFF
--- a/spring/src/main/java/com/example/spring/domain/serving/ServingTask.java
+++ b/spring/src/main/java/com/example/spring/domain/serving/ServingTask.java
@@ -21,6 +21,9 @@ public class ServingTask {
     @Column(name = "orderitem", nullable = false)
     private Long orderItemId;
 
+    @Column(name = "table_number")
+    private Integer tableNumber;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "status")
     private ServingStatus status;
@@ -46,9 +49,9 @@ public class ServingTask {
     private String key;
 
     @Builder
-    public ServingTask(Long boothId, Long orderItemId, String key) {
-        this.boothId = boothId;
+    public ServingTask(Long boothId, Long orderItemId, Integer tableNumber, String key) {        this.boothId = boothId;
         this.orderItemId = orderItemId;
+        this.tableNumber = tableNumber;
         this.status = ServingStatus.SERVE_REQUESTED;
         this.key = key;
         this.createdAt = LocalDateTime.now();

--- a/spring/src/main/java/com/example/spring/dto/redis/OrderCookedMessageDto.java
+++ b/spring/src/main/java/com/example/spring/dto/redis/OrderCookedMessageDto.java
@@ -1,6 +1,7 @@
 package com.example.spring.dto.redis;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,7 +15,7 @@ public class OrderCookedMessageDto {
     @JsonProperty("order_item_id")
     private Long orderItemId;
 
-    @JsonProperty("table_num")
+    @JsonAlias({"table_num", "table_number"})
     private Integer tableNum;
 
     @JsonProperty("menu_name")

--- a/spring/src/main/java/com/example/spring/dto/serving/response/ServingTaskResponse.java
+++ b/spring/src/main/java/com/example/spring/dto/serving/response/ServingTaskResponse.java
@@ -12,6 +12,7 @@ public class ServingTaskResponse {
 
     private Long taskId;
     private Long orderItemId;
+    private Integer tableNumber;
     private String status;
     // 🌟 catchedBy 필드 삭제됨
     private LocalDateTime requestedAt;
@@ -20,6 +21,7 @@ public class ServingTaskResponse {
         return ServingTaskResponse.builder()
                 .taskId(task.getId())
                 .orderItemId(task.getOrderItemId())
+                .tableNumber(task.getTableNumber())
                 .status(task.getStatus() != null ? task.getStatus().name() : null)
                 // 🌟 catchedBy 매핑 삭제됨
                 .requestedAt(task.getRequestedAt())

--- a/spring/src/main/java/com/example/spring/repository/serving/ServingTaskRepository.java
+++ b/spring/src/main/java/com/example/spring/repository/serving/ServingTaskRepository.java
@@ -5,6 +5,7 @@ import com.example.spring.domain.serving.ServingTask;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ServingTaskRepository extends JpaRepository<ServingTask, Long> {
 
@@ -13,4 +14,10 @@ public interface ServingTaskRepository extends JpaRepository<ServingTask, Long> 
      * 해당 부스의 서빙 대기 목록만 조회
      */
     List<ServingTask> findByBoothIdAndStatusOrderByRequestedAtAsc(Long boothId, ServingStatus status);
+
+    Optional<ServingTask> findFirstByBoothIdAndOrderItemIdAndStatusIn(Long boothId, Long orderItemId, List<ServingStatus> statuses);
+
+    long deleteByBoothIdAndOrderItemIdAndStatusIn(Long boothId, Long orderItemId, List<ServingStatus> statuses);
+
+    long deleteByBoothIdAndTableNumberAndStatusIn(Long boothId, Integer tableNumber, List<ServingStatus> statuses);
 }

--- a/spring/src/main/java/com/example/spring/service/serving/ServingTaskEventListener.java
+++ b/spring/src/main/java/com/example/spring/service/serving/ServingTaskEventListener.java
@@ -25,18 +25,55 @@ public class ServingTaskEventListener {
         String channel = event.getChannel();
         String message = event.getMessage();
 
-        if (channel.startsWith("django:booth:") && channel.endsWith(":order:cooked")) {
+        if (channel.startsWith("django:booth:") && channel.contains(":order:")) {
             try {
                 Long boothId = extractBoothId(channel);
+                String orderEvent = extractOrderEvent(channel);
                 OrderCookedMessageDto dto = objectMapper.readValue(message, OrderCookedMessageDto.class);
 
-                servingTaskService.createNewServingTask(
-                        boothId,
-                        dto.getOrderItemId(),
-                        UUID.randomUUID().toString()
-                );
+                if ("cooked".equals(orderEvent)) {
+                    if (dto.getOrderItemId() == null) {
+                        log.warn("[cooked 처리 스킵] order_item_id 누락. channel={}, message={}", channel, message);
+                        return;
+                    }
+                    if (dto.getTableNum() == null) {
+                        log.warn("[cooked 처리 경고] table_num/table_number 누락. 생성은 진행하지만 reset-by-table 정리에 실패할 수 있습니다. channel={}, message={}", channel, message);
+                    }
+                    servingTaskService.createNewServingTask(
+                            boothId,
+                            dto.getOrderItemId(),
+                            dto.getTableNum(),
+                            UUID.randomUUID().toString()
+                    );
+                    log.info("[서빙 태스크 생성 완료] boothId={}, orderItemId={}", boothId, dto.getOrderItemId());
+                    return;
+                }
 
-                log.info("[서빙 태스크 생성 완료] boothId={}, orderItemId={}", boothId, dto.getOrderItemId());
+                if ("served".equals(orderEvent)) {
+                    if (dto.getOrderItemId() == null) {
+                        log.warn("[served 처리 스킵] order_item_id 누락. channel={}, message={}", channel, message);
+                        return;
+                    }
+                    servingTaskService.removeTasksByOrderItemId(boothId, dto.getOrderItemId(), "ORDER_SERVED");
+                    return;
+                }
+
+                if ("cooking".equals(orderEvent)) {
+                    if (dto.getOrderItemId() == null) {
+                        log.warn("[cooking 처리 스킵] order_item_id 누락. channel={}, message={}", channel, message);
+                        return;
+                    }
+                    servingTaskService.removeTasksByOrderItemId(boothId, dto.getOrderItemId(), "COOKING_ROLLBACK");
+                    return;
+                }
+
+                if ("reset".equals(orderEvent)) {
+                    if (dto.getTableNum() == null) {
+                        log.warn("[reset 처리 스킵] table_num/table_number 누락. channel={}, message={}", channel, message);
+                        return;
+                    }
+                    servingTaskService.removeTasksByTableNumber(boothId, dto.getTableNum(), "TABLE_RESET");
+                }
 
             } catch (Exception e) {
                 log.error("[Redis 메시지 처리 실패] channel={}, message={}", channel, message, e);
@@ -53,5 +90,13 @@ public class ServingTaskEventListener {
             throw new IllegalArgumentException("유효하지 않은 채널 형식입니다: " + channel);
         }
         return Long.valueOf(parts[2]);
+    }
+
+    private String extractOrderEvent(String channel) {
+        String[] parts = channel.split(":");
+        if (parts.length < 5) {
+            throw new IllegalArgumentException("유효하지 않은 채널 형식입니다: " + channel);
+        }
+        return parts[4];
     }
 }

--- a/spring/src/main/java/com/example/spring/service/serving/ServingTaskService.java
+++ b/spring/src/main/java/com/example/spring/service/serving/ServingTaskService.java
@@ -14,13 +14,20 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime; // 🌟 LocalDateTime -> OffsetDateTime 으로 변경
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class ServingTaskService {
+
+    private static final List<ServingStatus> ACTIVE_SERVING_STATUSES = List.of(
+            ServingStatus.SERVE_REQUESTED,
+            ServingStatus.SERVING
+    );
 
     private final ServingTaskRepository servingTaskRepository;
     private final StringRedisTemplate redisTemplate;
@@ -104,10 +111,24 @@ public class ServingTaskService {
      * Django -> Spring : 조리 완료 알림 수신 시 새 serving_task 생성
      */
     @Transactional
-    public void createNewServingTask(Long boothId, Long orderItemId, String key) {
+    public void createNewServingTask(Long boothId, Long orderItemId, Integer tableNumber, String key) {
+        boolean alreadyExists = servingTaskRepository
+                .findFirstByBoothIdAndOrderItemIdAndStatusIn(
+                        boothId,
+                        orderItemId,
+                        ACTIVE_SERVING_STATUSES
+                )
+                .isPresent();
+
+        if (alreadyExists) {
+            log.info("[서빙 요청 중복 무시] boothId={}, orderItemId={}", boothId, orderItemId);
+            return;
+        }
+
         ServingTask newTask = ServingTask.builder()
                 .boothId(boothId)
                 .orderItemId(orderItemId)
+                .tableNumber(tableNumber)
                 .key(key)
                 .build();
 
@@ -115,6 +136,58 @@ public class ServingTaskService {
 
         webSocketHandler.broadcastEvent("NEW_CALL", ServingTaskResponse.from(newTask));
         log.info("[새 서빙 요청 생성 및 브로드캐스트] boothId={}, orderItemId={}", boothId, orderItemId);
+    }
+
+    @Transactional
+    public void removeTasksByOrderItemId(Long boothId, Long orderItemId, String reason) {
+        long deletedCount = servingTaskRepository.deleteByBoothIdAndOrderItemIdAndStatusIn(
+                boothId,
+                orderItemId,
+                ACTIVE_SERVING_STATUSES
+        );
+        if (deletedCount > 0) {
+            webSocketHandler.broadcastEvent(
+                    "REMOVE_CALL",
+                    buildRemoveCallPayload(boothId, reason, deletedCount, orderItemId, null)
+            );
+        }
+        log.info("[서빙 요청 삭제] boothId={}, orderItemId={}, reason={}, deletedCount={}", boothId, orderItemId, reason, deletedCount);
+    }
+
+    @Transactional
+    public void removeTasksByTableNumber(Long boothId, Integer tableNumber, String reason) {
+        long deletedCount = servingTaskRepository.deleteByBoothIdAndTableNumberAndStatusIn(
+                boothId,
+                tableNumber,
+                ACTIVE_SERVING_STATUSES
+        );
+        if (deletedCount > 0) {
+            webSocketHandler.broadcastEvent(
+                    "REMOVE_CALL",
+                    buildRemoveCallPayload(boothId, reason, deletedCount, null, tableNumber)
+            );
+        }
+        log.info("[테이블 기준 서빙 요청 삭제] boothId={}, tableNumber={}, reason={}, deletedCount={}", boothId, tableNumber, reason, deletedCount);
+    }
+
+    private Map<String, Object> buildRemoveCallPayload(
+            Long boothId,
+            String reason,
+            long deletedCount,
+            Long orderItemId,
+            Integer tableNumber
+    ) {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("boothId", boothId);
+        payload.put("reason", reason);
+        payload.put("deletedCount", deletedCount);
+        if (orderItemId != null) {
+            payload.put("orderItemId", orderItemId);
+        }
+        if (tableNumber != null) {
+            payload.put("tableNumber", tableNumber);
+        }
+        return payload;
     }
 
     // 🌟 catchedBy 파라미터 삭제


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

- Django-Spring 서빙 라이프사이클 동기화 및 멱등성 보장
- ServingTask 엔티티 수정 (tableNumber 필드 추가)
- Redis Pub/Sub 이벤트 처리 확장 (cooked, served, cooking, reset)
- WebSocket REMOVE_CALL 이벤트 추가

## 📍 PR Point
멱등성 보장: cooked 이벤트 수신 시, 기존에 진행 중인 서빙 요청이 있다면 무시하여 무한 증식 버그를 해결했습니다.

테이블 단위 초기화: reset 이벤트 수신 시 tableNumber를 기준으로 해당 테이블의 모든 서빙 요청을 일괄 정리합니다.

Soft Delete 도입: 데이터 추적성을 위해 DB에서 직접 삭제하는 대신 ServingStatus를 활용하여 상태 변경(취소/완료)을 관리하도록 변경했습니다.

데이터 정합성: Django에서 발행하는 다양한 이벤트에 대응하도록 Spring의 이벤트 리스너를 세분화했습니다.

## 📢 Notices

의존성 변경: Django 측 Redis Payload에 table_number 및 order_item_id 필드가 포함되어야 정상적으로 동작합니다.

DB 구조: serving_task 테이블에 table_number 컬럼이 필요합니다. (JPA ddl-auto: update 설정 확인 요망)
## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #
<!-- - ex) #278 