### PR TITLE
🐛 [Fix] #307 - 병합되었지만 미사용 중인 테이블 초기화 허용

### DIFF
--- a/django/table/services.py
+++ b/django/table/services.py
@@ -3,6 +3,7 @@ import logging
 from .models import Table, TableGroup, TableUsage
 from django.utils.timezone import now
 from django.db import transaction
+from django.db.models import Q
 from rest_framework.exceptions import ValidationError, NotFound
 from channels.layers import get_channel_layer
 from asgiref.sync import async_to_sync
@@ -286,8 +287,11 @@ class TableService:
             table_num__in=table_nums,
         )
 
-        if tables.exclude(status=Table.Status.IN_USE).exists():
-            raise ValidationError('사용중인 테이블만 초기화 할 수 있습니다.')
+        if tables.filter(
+            Q(status=Table.Status.INACTIVE)
+            | Q(status=Table.Status.ACTIVE, group__isnull=True)
+        ).exists():
+            raise ValidationError('사용중이거나 병합된 테이블만 초기화 할 수 있습니다.')
         
         # 3. 존재하지 않는 테이블 확인
         found_count = tables.count()

--- a/django/table/tests.py
+++ b/django/table/tests.py
@@ -431,6 +431,33 @@ class TableResetTestCase(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
+    def test_reset_merged_tables_without_active_session(self):
+        """병합되었지만 IN_USE가 아닌 테이블도 초기화로 병합 해제 가능 (#307)"""
+        self.client.force_authenticate(user=self.user)
+        self.client.post(MERGE_URL, {'table_nums': [1, 2, 3]}, format='json')
+
+        for table_num in [1, 2, 3]:
+            table = Table.objects.get(booth=self.booth, table_num=table_num)
+            self.assertEqual(table.status, Table.Status.ACTIVE)
+            self.assertIsNotNone(table.group)
+
+        response = self.client.post(RESET_URL, {'table_nums': [1]}, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for table_num in [1, 2, 3]:
+            table = Table.objects.get(booth=self.booth, table_num=table_num)
+            self.assertEqual(table.status, Table.Status.ACTIVE)
+            self.assertIsNone(table.group)
+
+    def test_reset_idle_unmerged_table_rejected(self):
+        """병합되지 않은 미사용 테이블은 여전히 초기화 거부"""
+        self.client.force_authenticate(user=self.user)
+
+        with suppress_request_warnings():
+            response = self.client.post(RESET_URL, {'table_nums': [1]}, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
 
 @override_settings(STORAGES=IN_MEMORY_STORAGES)
 class TableMergeTestCase(APITestCase):


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

- 병합된 테이블이지만 활성 TableUsage가 없는 경우(=세션이 시작되지 않거나 외부 경로로 종료된 경우)에도 `reset_tables`로 병합 해제가 가능하도록 게이트 조건 완화
- 회귀 방지용 테스트 2건 추가

## 📍 PR Point

- `django/table/services.py` 의 초기화 게이트만 수정. 본문(`group` 해제, `TableUsage.update`, `status=ACTIVE` 처리)은 이미 활성 usage가 0개인 경우를 멱등하게 처리하므로 추가 변경 없음
- 새 허용 조건: **IN_USE** 또는 **병합 그룹 소속(`group_id IS NOT NULL`)**
- 거부 대상: `INACTIVE` 또는 `(AVAILABLE && 미병합)` — "초기화할 게 없는" 케이스만 거부

```python
if tables.filter(
    Q(status=Table.Status.INACTIVE)
    | Q(status=Table.Status.ACTIVE, group__isnull=True)
).exists():
    raise ValidationError('사용중이거나 병합된 테이블만 초기화 할 수 있습니다.')
```

## 📢 Notices

 <!-- 공용으로 사용하는(Extension) 부분에 대한 설명 -->
- Spring 측 `TableService.resetTables()` 는 Django REST 호출만 하므로 변경 없음
- WebSocket 브로드캐스트, Spring Redis publish, 서빙 태스크 취소 로직 그대로
- 추가된 테스트
  - `test_reset_merged_tables_without_active_session`: IN_USE가 아닌 병합 테이블 초기화 시 그룹 해제 + AVAILABLE 유지 검증 (#307 회귀 방지)
  - `test_reset_idle_unmerged_table_rejected`: 미병합·미사용 테이블은 여전히 400 거부
- `pytest table` 81건 모두 통과

## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #307