### PR TITLE
🐛 [Fix] - 할인율(RATE) 쿠폰 생성 validation 로직 수정

### DIFF
--- a/django/coupon/serializers.py
+++ b/django/coupon/serializers.py
@@ -21,11 +21,26 @@ class CouponCreateSerializer(serializers.Serializer):
         dv: Decimal = attrs["discount_value"]
 
         if dt == "RATE":
-            if not (Decimal("0") < dv < Decimal("1")):
-                raise serializers.ValidationError({"discount_value": "RATE는 0보다 크고 1보다 작아야 합니다."})
+            if dv <= Decimal("0"):
+                raise serializers.ValidationError(
+                    {"discount_value": "RATE는 0보다 커야 합니다."}
+                )
+
+            if dv >= Decimal("1"):
+                if dv > Decimal("100"):
+                    raise serializers.ValidationError(
+                        {"discount_value": "RATE는 100 이하의 값이어야 합니다."}
+                    )
+                attrs["discount_value"] = dv / Decimal("100")
+
+            elif dv < Decimal("1"):
+                attrs["discount_value"] = dv
+
         else:
             if dv < Decimal("1"):
-                raise serializers.ValidationError({"discount_value": "AMOUNT는 1 이상이어야 합니다."})
+                raise serializers.ValidationError(
+                    {"discount_value": "AMOUNT는 1 이상이어야 합니다."}
+                )
 
         return attrs
 


### PR DESCRIPTION
## 🔍 What is the PR?
- 할인율(RATE) 쿠폰 생성 불가 문제 수정
- RATE 쿠폰 생성 시 퍼센트 값(10, 20 등)을 정상 처리하도록 validation 로직 개선
- 할인율 입력값을 내부적으로 소수 형태로 변환하도록 수정

## 📍 PR Point
- 프론트에서 일반적인 퍼센트 값으로 요청해도 정상적으로 쿠폰 생성 가능
- 기존 할인 계산 로직과 호환되도록 serializer 단계에서 변환 처리

## 📢 Notices
- RATE 쿠폰은 10 → 0.10 형태로 변환되어 저장
- 기존 0.1 형태 입력도 그대로 사용 가능

## ✅ Check List
- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues
- #309 