### PR TITLE
🐛 [Fix] #311 - 결제 확정 시 테이블 WebSocket order_update 미발행 수정

### DIFF
--- a/django/cart/services.py
+++ b/django/cart/services.py
@@ -789,7 +789,14 @@ def confirm_payment_and_mark_ordered(*, table_usage_id: int) -> Cart:
     cart.save(update_fields=["status", "pending_expires_at"])
 
     final_table_usage_id = cart.table_usage_id
-    booth_id = cart.table_usage.table.booth_id
+    table = cart.table_usage.table
+    booth_id = table.booth_id
+    table_num = table.table_num
+
+    from table.services import OrderBroadcastService
+    OrderBroadcastService.broadcast_order_update(
+        booth_id, table_num, final_table_usage_id
+    )
 
     from .services_ws import broadcast_cart_event
     from order.cache import update_today_revenue

--- a/django/table/services.py
+++ b/django/table/services.py
@@ -141,8 +141,11 @@ class OrderBroadcastService:
                     f"[OrderBroadcast] booth={booth_id} table={table_num} "
                     f"주문 {len(all_orders)}건 브로드캐스트 완료"
                 )
-            except Exception as e:
-                logger.error(f"[OrderBroadcast] 전송 실패: {e}")
+            except Exception:
+                logger.exception(
+                    f"[OrderBroadcast] 전송 실패 booth={booth_id} "
+                    f"table={table_num} table_usage={table_usage_id}"
+                )
 
         transaction.on_commit(_send)
 


### PR DESCRIPTION
## 🔍 What is the PR?

- `cart.services.confirm_payment_and_mark_ordered` 에 `OrderBroadcastService.broadcast_order_update` 호출 추가 — 결제 확정으로 새 주문이 생성될 때 테이블 WebSocket 그룹(`booth_{id}.tables`, `booth_{id}.tables.{table_num}`) 으로 `order_update` 이벤트가 발행되도록 수정
- `OrderBroadcastService._send` 의 `except` 블록을 `logger.exception(...)` 으로 교체 — 동일 증상 재발 시 traceback 이 함께 남도록 개선

## 📍 PR Point

- 그동안 V3 결제 확정 경로(`POST /cart/payment-confirm/`)는 Spring Redis pub/sub 가 아닌 Django 내부에서 직접 `_finalize_payment_core` 로 Order 를 생성해 왔는데, 이 경로에 `broadcast_order_update` 호출이 빠져 있어 테이블 목록/상세 WS 가 새 주문을 받지 못하고 있었습니다.
- 기존 `_send` 의 예외 핸들러는 `logger.error(f"...: {e}")` 한 줄만 남겨 어디서 무엇이 실패했는지 알 수 없었는데, `logger.exception` 으로 바꿔 traceback 을 보존합니다.

## 📢 Notices

- 다른 트리거(`update_order_item_status`, `cancel_order_item`, `handle_serving_event`, `create_order_from_event`)에는 `broadcast_order_update` 호출이 이미 들어 있으므로 이번 변경은 결제 확정 경로 한 곳에 한정됩니다.

## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가? (→ `dev`)
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

- #311