### PR TITLE
✨ [Feat] - #324 첫번쨰 QA에 대한 수정을 진행한다

### DIFF
--- a/spring/src/main/java/com/example/spring/domain/cart/CartEntity.java
+++ b/spring/src/main/java/com/example/spring/domain/cart/CartEntity.java
@@ -20,7 +20,11 @@ public class CartEntity {
     @Column(name = "table_usage_id", nullable = false)
     private Long tableUsageId;
 
-    /** Django cart_cart.cart_price — 장바구니 총 금액 */
+    /** Django cart_cart.cart_price — 품목 합(소계), 쿠폰 전 */
     @Column(name = "cart_price", nullable = false)
     private Integer cartPrice;
+
+    /** Django cart_cart.round — CartCouponApply와 동일 round에 매칭 */
+    @Column(name = "round", nullable = false)
+    private Integer round;
 }

--- a/spring/src/main/java/com/example/spring/domain/staffcall/StaffCall.java
+++ b/spring/src/main/java/com/example/spring/domain/staffcall/StaffCall.java
@@ -33,7 +33,7 @@ public class StaffCall {
     @Column(name = "table_num")
     private Integer tableNum;
 
-    /** Django cart_cart.cart_price — 결제확인 모달 금액 표시용 */
+    /** emit 시점 부담 금액(쿠폰 할인 반영). Django 장바구니 스냅샷 summary.total 과 맞춤 */
     @Column(name = "cart_price")
     private Integer cartPrice;
 

--- a/spring/src/main/java/com/example/spring/domain/staffcall/StaffCall.java
+++ b/spring/src/main/java/com/example/spring/domain/staffcall/StaffCall.java
@@ -46,7 +46,7 @@ public class StaffCall {
     private StaffCallCategory category;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false, length = 16)
+    @Column(name = "status", nullable = false, length = 32)
     private StaffCallStatus status;
 
     @Column(name = "created_at", nullable = false)
@@ -102,5 +102,14 @@ public class StaffCall {
         this.status = StaffCallStatus.COMPLETED;
         this.completedAt = LocalDateTime.now();
         this.updatedAt = this.completedAt;
+    }
+
+    /** Django 테이블 초기화로 세션이 끊긴 경우 — 활성 호출만 목록에서 제외. */
+    public void cancelDueToTableReset() {
+        if (this.status != StaffCallStatus.PENDING && this.status != StaffCallStatus.ACCEPTED) {
+            return;
+        }
+        this.status = StaffCallStatus.VOIDED_BY_RESET;
+        this.updatedAt = LocalDateTime.now();
     }
 }

--- a/spring/src/main/java/com/example/spring/domain/staffcall/StaffCallStatus.java
+++ b/spring/src/main/java/com/example/spring/domain/staffcall/StaffCallStatus.java
@@ -4,5 +4,6 @@ public enum StaffCallStatus {
     PENDING,
     ACCEPTED,
     COMPLETED,
-    CANCELLED
+    CANCELLED,
+    VOIDED_BY_RESET,
 }

--- a/spring/src/main/java/com/example/spring/repository/staffcall/StaffCallRepository.java
+++ b/spring/src/main/java/com/example/spring/repository/staffcall/StaffCallRepository.java
@@ -68,4 +68,12 @@ public interface StaffCallRepository extends JpaRepository<StaffCall, Long> {
             String callType,
             Collection<StaffCallStatus> statuses
     );
+
+    @Query("SELECT sc FROM StaffCall sc WHERE sc.boothId = :boothId AND sc.tableNum = :tableNum "
+            + "AND sc.status IN :statuses")
+    List<StaffCall> findByBoothIdAndTableNumAndStatusIn(
+            @Param("boothId") Long boothId,
+            @Param("tableNum") Integer tableNum,
+            @Param("statuses") Collection<StaffCallStatus> statuses
+    );
 }

--- a/spring/src/main/java/com/example/spring/service/cart/CartPayableAmountService.java
+++ b/spring/src/main/java/com/example/spring/service/cart/CartPayableAmountService.java
@@ -1,0 +1,83 @@
+package com.example.spring.service.cart;
+
+import com.example.spring.domain.cart.CartEntity;
+import com.example.spring.repository.cart.CartEntityRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Django {@code cart.services._calc_discount} + {@code build_cart_snapshot_data}와 동일한 규칙으로
+ * 쿠폰 적용 후 실제 부담 금액(소계 − 할인)을 계산한다.
+ * <p>
+ * {@code cart_cart.cart_price}는 항상 품목 합(쿠폰 전)이므로, 쿠폰은 {@code coupon_cartcouponapply}에서 조회한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class CartPayableAmountService {
+
+    private final CartEntityRepository cartEntityRepository;
+    private final JdbcTemplate jdbcTemplate;
+
+    /**
+     * @return 쿠폰 반영 금액(0 이상). 쿠폰 없으면 {@code cart_price}와 동일.
+     */
+    public int resolvePayableTotal(long cartId) {
+        CartEntity cart = cartEntityRepository.findById(cartId)
+                .orElseThrow(() -> new IllegalArgumentException("카트를 찾을 수 없습니다."));
+        return resolvePayableTotal(cart);
+    }
+
+    public int resolvePayableTotal(CartEntity cart) {
+        int subtotal = cart.getCartPrice() != null ? cart.getCartPrice() : 0;
+        int round = cart.getRound() != null ? cart.getRound() : 0;
+
+        Optional<DiscountRow> applied = findAppliedCoupon(cart.getId(), round);
+        if (applied.isEmpty()) {
+            return subtotal;
+        }
+        int discount = calcDiscount(subtotal, applied.get().discountType(), applied.get().discountValue());
+        return Math.max(0, subtotal - discount);
+    }
+
+    private Optional<DiscountRow> findAppliedCoupon(long cartId, int round) {
+        String sql = """
+                SELECT cp.discount_type, cp.discount_value
+                FROM coupon_cartcouponapply a
+                JOIN coupon_couponcode cc ON a.coupon_code_id = cc.id
+                JOIN coupon_coupon cp ON cc.coupon_id = cp.id
+                WHERE a.cart_id = ? AND a.round = ?
+                LIMIT 1
+                """;
+        List<DiscountRow> rows = jdbcTemplate.query(sql, (rs, rowNum) -> new DiscountRow(
+                rs.getString("discount_type"),
+                rs.getBigDecimal("discount_value")
+        ), cartId, round);
+        return rows.stream().findFirst();
+    }
+
+    /**
+     * Django {@code _calc_discount} 이식
+     */
+    private static int calcDiscount(int subtotal, String discountType, BigDecimal discountValue) {
+        if (subtotal <= 0) {
+            return 0;
+        }
+        if (discountValue == null) {
+            return 0;
+        }
+        if ("RATE".equals(discountType)) {
+            int amt = (int) (subtotal * discountValue.doubleValue());
+            return Math.max(0, Math.min(subtotal, amt));
+        }
+        int amt = discountValue.intValue();
+        return Math.max(0, Math.min(subtotal, amt));
+    }
+
+    private record DiscountRow(String discountType, BigDecimal discountValue) {
+    }
+}

--- a/spring/src/main/java/com/example/spring/service/serving/ServingTaskEventListener.java
+++ b/spring/src/main/java/com/example/spring/service/serving/ServingTaskEventListener.java
@@ -2,6 +2,7 @@ package com.example.spring.service.serving;
 
 import com.example.spring.dto.redis.OrderCookedMessageDto;
 import com.example.spring.event.RedisMessageEvent;
+import com.example.spring.service.staffcall.StaffCallTableResetService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +18,7 @@ import java.util.UUID;
 public class ServingTaskEventListener {
 
     private final ServingTaskService servingTaskService;
+    private final StaffCallTableResetService staffCallTableResetService;
     private final ObjectMapper objectMapper;
 
     @EventListener
@@ -73,6 +75,7 @@ public class ServingTaskEventListener {
                         return;
                     }
                     servingTaskService.removeTasksByTableNumber(boothId, dto.getTableNum(), "TABLE_RESET");
+                    staffCallTableResetService.voidActiveCallsForTable(boothId, dto.getTableNum());
                 }
 
             } catch (Exception e) {

--- a/spring/src/main/java/com/example/spring/service/staffcall/StaffCallService.java
+++ b/spring/src/main/java/com/example/spring/service/staffcall/StaffCallService.java
@@ -14,6 +14,7 @@ import com.example.spring.dto.staffcall.request.StaffCallDeleteRequest;
 import com.example.spring.dto.staffcall.request.StaffCallEmitRequest;
 import com.example.spring.dto.staffcall.response.StaffCallAcceptResponse;
 import com.example.spring.dto.staffcall.response.StaffCallItemResponse;
+import com.example.spring.service.cart.CartPayableAmountService;
 import com.example.spring.repository.cart.CartEntityRepository;
 import com.example.spring.repository.staffcall.StaffCallRepository;
 import com.example.spring.repository.table.BoothTableRepository;
@@ -43,6 +44,7 @@ public class StaffCallService {
     private final StaffCallQueryService staffCallQueryService;
     private final BoothTableRepository boothTableRepository;
     private final CartEntityRepository cartEntityRepository;
+    private final CartPayableAmountService cartPayableAmountService;
     private final TableUsageEntityRepository tableUsageEntityRepository;
     private final JwtUtil jwtUtil;
     private final ObjectMapper objectMapper;
@@ -259,12 +261,14 @@ public class StaffCallService {
             throw new StaffCallConflictException("동일한 호출이 이미 진행 중입니다.");
         }
 
+        int displayCartPrice = cartPayableAmountService.resolvePayableTotal(cart);
+
         StaffCall sc = StaffCall.builder()
                 .boothId(boothId)
                 .tableId(actualTableId)
                 .tableUsageId(cart.getTableUsageId())
                 .tableNum(table.getTableNum())
-                .cartPrice(cart.getCartPrice())
+                .cartPrice(displayCartPrice)
                 .cartId(req.getCartId())
                 .callType(req.getCallType())
                 .category(req.getCategory())

--- a/spring/src/main/java/com/example/spring/service/staffcall/StaffCallTableResetService.java
+++ b/spring/src/main/java/com/example/spring/service/staffcall/StaffCallTableResetService.java
@@ -1,0 +1,69 @@
+package com.example.spring.service.staffcall;
+
+import com.example.spring.domain.staffcall.StaffCall;
+import com.example.spring.domain.staffcall.StaffCallStatus;
+import com.example.spring.repository.staffcall.StaffCallRepository;
+import com.example.spring.websocket.CustomerStaffCallWebSocketHandler;
+import com.example.spring.websocket.StaffCallWebSocketHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.EnumSet;
+import java.util.List;
+
+/**
+ * Django 테이블 초기화 시 Redis({@code django:booth:*:order:reset})와 맞춰
+ * 해당 부스·테이블 번호의 활성 직원 호출을 목록에서 제외한다({@link StaffCallStatus#VOIDED_BY_RESET}).
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StaffCallTableResetService {
+
+    private final StaffCallRepository staffCallRepository;
+    private final StaffCallQueryService staffCallQueryService;
+
+    @Lazy
+    @Autowired
+    private StaffCallWebSocketHandler staffCallWebSocketHandler;
+
+    @Lazy
+    @Autowired
+    private CustomerStaffCallWebSocketHandler customerStaffCallWebSocketHandler;
+
+    @Transactional
+    public void voidActiveCallsForTable(Long boothId, Integer tableNum) {
+        if (boothId == null || tableNum == null) {
+            return;
+        }
+
+        List<StaffCall> active = staffCallRepository.findByBoothIdAndTableNumAndStatusIn(
+                boothId,
+                tableNum,
+                EnumSet.of(StaffCallStatus.PENDING, StaffCallStatus.ACCEPTED));
+
+        if (active.isEmpty()) {
+            return;
+        }
+
+        for (StaffCall sc : active) {
+            sc.cancelDueToTableReset();
+        }
+        staffCallRepository.saveAll(active);
+
+        try {
+            staffCallWebSocketHandler.broadcastSnapshot(boothId,
+                    staffCallQueryService.listForBooth(boothId, 50, 0));
+            for (StaffCall sc : active) {
+                customerStaffCallWebSocketHandler.broadcastStatus(sc);
+            }
+        } catch (Exception e) {
+            log.error("[staffcall table reset] 스냅샷/고객 WS 푸시 실패 — DB 반영은 완료 boothId={}, tableNum={}",
+                    boothId, tableNum, e);
+        }
+    }
+}


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->
테이블 초기화 시 Django Redis(django:booth:{id}:order:reset)에 맞춰, 스프링 DB의 활성 직원 호출(PENDING / ACCEPTED) 을 VOIDED_BY_RESET 으로 바꿔 직원 목록·스냅샷에서 제외\

직원 호출 등록(emit) 시 cart_cart.cart_price(소계) 대신 CartCouponApply + Django와 동일 할인 규칙으로 계산한 쿠폰 반영 부담 금액을 StaffCall.cart_price·Redis·API 응답에 반영

## 📍 PR Point

<!-- 나 이 부분 찢었다~! -->


테이블/세션·주문 본편: 기존처럼 Django
스프링에만 있는 StaffCall 정리: Redis order:reset + table_num 수신 시 StaffCallTableResetService에서 일괄 처리

cart_price 컬럼만 보면 쿠폰 전 소계라서, coupon_cartcouponapply 조인 + _calc_discount 이식으로 할인 후 합계를 emit 시점에만 계산 (스키마 추가 없이 공유 DB 활용)


## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #324
<!-- - ex) #3 -->