### PR TITLE
[Fix] #326 - 테이블 초기화 시 해당 테이블의 모든 StaffCall을 VOIDED_BY_RESET 처리 (PEND…

### DIFF
--- a/spring/src/main/java/com/example/spring/domain/staffcall/StaffCall.java
+++ b/spring/src/main/java/com/example/spring/domain/staffcall/StaffCall.java
@@ -104,9 +104,9 @@ public class StaffCall {
         this.updatedAt = this.completedAt;
     }
 
-    /** Django 테이블 초기화로 세션이 끊긴 경우 — 활성 호출만 목록에서 제외. */
+    /** Django 테이블 초기화로 해당 테이블 호출 이력을 목록에서 제외(PENDING/ACCEPTED/COMPLETED 등 전부). */
     public void cancelDueToTableReset() {
-        if (this.status != StaffCallStatus.PENDING && this.status != StaffCallStatus.ACCEPTED) {
+        if (this.status == StaffCallStatus.VOIDED_BY_RESET) {
             return;
         }
         this.status = StaffCallStatus.VOIDED_BY_RESET;

--- a/spring/src/main/java/com/example/spring/repository/staffcall/StaffCallRepository.java
+++ b/spring/src/main/java/com/example/spring/repository/staffcall/StaffCallRepository.java
@@ -69,11 +69,12 @@ public interface StaffCallRepository extends JpaRepository<StaffCall, Long> {
             Collection<StaffCallStatus> statuses
     );
 
+    /** 테이블 초기화 시 해당 부스·테이블 번호의 모든 호출을 무효화하기 위해, 이미 무효인 행은 제외한다. */
     @Query("SELECT sc FROM StaffCall sc WHERE sc.boothId = :boothId AND sc.tableNum = :tableNum "
-            + "AND sc.status IN :statuses")
-    List<StaffCall> findByBoothIdAndTableNumAndStatusIn(
+            + "AND sc.status <> :voidedByReset")
+    List<StaffCall> findByBoothIdAndTableNumWhereStatusNotVoidedByReset(
             @Param("boothId") Long boothId,
             @Param("tableNum") Integer tableNum,
-            @Param("statuses") Collection<StaffCallStatus> statuses
+            @Param("voidedByReset") StaffCallStatus voidedByReset
     );
 }

--- a/spring/src/main/java/com/example/spring/service/staffcall/StaffCallTableResetService.java
+++ b/spring/src/main/java/com/example/spring/service/staffcall/StaffCallTableResetService.java
@@ -12,12 +12,11 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.EnumSet;
 import java.util.List;
 
 /**
  * Django 테이블 초기화 시 Redis({@code django:booth:*:order:reset})와 맞춰
- * 해당 부스·테이블 번호의 활성 직원 호출을 목록에서 제외한다({@link StaffCallStatus#VOIDED_BY_RESET}).
+ * 해당 부스·테이블 번호의 직원 호출을 모두 목록에서 제외한다({@link StaffCallStatus#VOIDED_BY_RESET}).
  */
 @Slf4j
 @Service
@@ -41,24 +40,24 @@ public class StaffCallTableResetService {
             return;
         }
 
-        List<StaffCall> active = staffCallRepository.findByBoothIdAndTableNumAndStatusIn(
+        List<StaffCall> toVoid = staffCallRepository.findByBoothIdAndTableNumWhereStatusNotVoidedByReset(
                 boothId,
                 tableNum,
-                EnumSet.of(StaffCallStatus.PENDING, StaffCallStatus.ACCEPTED));
+                StaffCallStatus.VOIDED_BY_RESET);
 
-        if (active.isEmpty()) {
+        if (toVoid.isEmpty()) {
             return;
         }
 
-        for (StaffCall sc : active) {
+        for (StaffCall sc : toVoid) {
             sc.cancelDueToTableReset();
         }
-        staffCallRepository.saveAll(active);
+        staffCallRepository.saveAll(toVoid);
 
         try {
             staffCallWebSocketHandler.broadcastSnapshot(boothId,
                     staffCallQueryService.listForBooth(boothId, 50, 0));
-            for (StaffCall sc : active) {
+            for (StaffCall sc : toVoid) {
                 customerStaffCallWebSocketHandler.broadcastStatus(sc);
             }
         } catch (Exception e) {


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->
테이블 초기화 시 해당 테이블의 모든 StaffCall을 VOIDED_BY_RESET 처리

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #326
<!-- - ex) #3 -->