### PR TITLE
[Fix] #328 - staff_call 테이블 리셋 시 VOIDED_BY_RESET 제거하고 CANCELLED로 통합

### DIFF
--- a/spring/src/main/java/com/example/spring/domain/staffcall/StaffCall.java
+++ b/spring/src/main/java/com/example/spring/domain/staffcall/StaffCall.java
@@ -104,12 +104,12 @@ public class StaffCall {
         this.updatedAt = this.completedAt;
     }
 
-    /** Django 테이블 초기화로 해당 테이블 호출 이력을 목록에서 제외(PENDING/ACCEPTED/COMPLETED 등 전부). */
+    /** Django 테이블 초기화로 해당 테이블 호출을 취소 처리(PENDING/ACCEPTED/COMPLETED 등 → {@link StaffCallStatus#CANCELLED}). */
     public void cancelDueToTableReset() {
-        if (this.status == StaffCallStatus.VOIDED_BY_RESET) {
+        if (this.status == StaffCallStatus.CANCELLED) {
             return;
         }
-        this.status = StaffCallStatus.VOIDED_BY_RESET;
+        this.status = StaffCallStatus.CANCELLED;
         this.updatedAt = LocalDateTime.now();
     }
 }

--- a/spring/src/main/java/com/example/spring/domain/staffcall/StaffCallStatus.java
+++ b/spring/src/main/java/com/example/spring/domain/staffcall/StaffCallStatus.java
@@ -5,5 +5,4 @@ public enum StaffCallStatus {
     ACCEPTED,
     COMPLETED,
     CANCELLED,
-    VOIDED_BY_RESET,
 }

--- a/spring/src/main/java/com/example/spring/repository/staffcall/StaffCallRepository.java
+++ b/spring/src/main/java/com/example/spring/repository/staffcall/StaffCallRepository.java
@@ -69,12 +69,10 @@ public interface StaffCallRepository extends JpaRepository<StaffCall, Long> {
             Collection<StaffCallStatus> statuses
     );
 
-    /** 테이블 초기화 시 해당 부스·테이블 번호의 모든 호출을 무효화하기 위해, 이미 무효인 행은 제외한다. */
-    @Query("SELECT sc FROM StaffCall sc WHERE sc.boothId = :boothId AND sc.tableNum = :tableNum "
-            + "AND sc.status <> :voidedByReset")
-    List<StaffCall> findByBoothIdAndTableNumWhereStatusNotVoidedByReset(
-            @Param("boothId") Long boothId,
-            @Param("tableNum") Integer tableNum,
-            @Param("voidedByReset") StaffCallStatus voidedByReset
+    /** 테이블 초기화 시 무효화 대상: 이미 {@link StaffCallStatus#CANCELLED}인 행은 제외. */
+    List<StaffCall> findByBoothIdAndTableNumAndStatusNot(
+            Long boothId,
+            Integer tableNum,
+            StaffCallStatus status
     );
 }

--- a/spring/src/main/java/com/example/spring/service/staffcall/StaffCallTableResetService.java
+++ b/spring/src/main/java/com/example/spring/service/staffcall/StaffCallTableResetService.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 /**
  * Django 테이블 초기화 시 Redis({@code django:booth:*:order:reset})와 맞춰
- * 해당 부스·테이블 번호의 직원 호출을 모두 목록에서 제외한다({@link StaffCallStatus#VOIDED_BY_RESET}).
+ * 해당 부스·테이블 번호의 직원 호출을 {@link StaffCallStatus#CANCELLED}로 맞춘다(이미 취소된 행은 스킵).
  */
 @Slf4j
 @Service
@@ -40,10 +40,10 @@ public class StaffCallTableResetService {
             return;
         }
 
-        List<StaffCall> toVoid = staffCallRepository.findByBoothIdAndTableNumWhereStatusNotVoidedByReset(
+        List<StaffCall> toVoid = staffCallRepository.findByBoothIdAndTableNumAndStatusNot(
                 boothId,
                 tableNum,
-                StaffCallStatus.VOIDED_BY_RESET);
+                StaffCallStatus.CANCELLED);
 
         if (toVoid.isEmpty()) {
             return;


### PR DESCRIPTION
Made-with: Cursor

<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->
staff_call 테이블 리셋 시 VOIDED_BY_RESET 제거하고 CANCELLED로 통합

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #328
<!-- - ex) #3 -->