### PR TITLE
[Fix] #334 - order:reset 페이로드 분기 보완 및 table_num JSON 보조파싱

### DIFF
--- a/spring/src/main/java/com/example/spring/service/serving/ServingTaskEventListener.java
+++ b/spring/src/main/java/com/example/spring/service/serving/ServingTaskEventListener.java
@@ -5,6 +5,7 @@ import com.example.spring.event.RedisMessageEvent;
 import com.example.spring.domain.staffcall.StaffCall;
 import com.example.spring.service.staffcall.StaffCallTableResetService;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -78,21 +79,33 @@ public class ServingTaskEventListener {
                 }
 
                 if ("reset".equals(orderEvent)) {
-                    if (dto.getTableNum() == null) {
-                        log.warn("[테이블 초기화 처리 스킵] table_num/table_number 누락. channel={}, message={}",
+                    /*
+                     * 같은 채널 django:booth:*:order:reset 에 (1) 테이블 초기화용 {"table_num":n}
+                     * (2) 서빙취소용 {"order_item_id":...} 가 함께 온다. (2)는 Spring 테이블 초기화와 무관.
+                     * table_num 이 문자열이면 DTO Integer 가 null 일 수 있어 JSON 보조 파싱을 먼저 한다.
+                     */
+                    Integer tableNumFromJson = extractTableNumFromResetJson(message);
+                    if (dto.getOrderItemId() != null && dto.getTableNum() == null && tableNumFromJson == null) {
+                        log.info("[Redis 주문] order:reset — 테이블 초기화 페이로드 아님(서빙 취소 등) boothId={}, orderItemId={}, 건너뜀",
+                                boothId, dto.getOrderItemId());
+                        return;
+                    }
+                    Integer tableNum = dto.getTableNum() != null ? dto.getTableNum() : tableNumFromJson;
+                    if (tableNum == null) {
+                        log.warn("[테이블 초기화 처리 스킵] table_num 없음·파싱 불가. channel={}, message={}",
                                 channel, truncateForLog(message, 2000));
                         return;
                     }
-                    log.info("[테이블 초기화] 서빙태스크 삭제 직전 boothId={}, tableNum={}", boothId, dto.getTableNum());
-                    servingTaskService.removeTasksByTableNumber(boothId, dto.getTableNum(), "TABLE_RESET");
-                    log.info("[테이블 초기화] staff_call 취소 호출 직전 boothId={}, tableNum={}", boothId, dto.getTableNum());
+                    log.info("[테이블 초기화] 서빙태스크 삭제 직전 boothId={}, tableNum={}", boothId, tableNum);
+                    servingTaskService.removeTasksByTableNumber(boothId, tableNum, "TABLE_RESET");
+                    log.info("[테이블 초기화] staff_call 취소 호출 직전 boothId={}, tableNum={}", boothId, tableNum);
                     List<StaffCall> voided = staffCallTableResetService.voidActiveCallsForTable(
-                            boothId, dto.getTableNum());
+                            boothId, tableNum);
                     log.info("[테이블 초기화] 스냅샷·WS 호출 직전 boothId={}, staffCall취소건수={}",
                             boothId, voided.size());
                     staffCallTableResetService.publishTableResetNotifications(boothId, voided);
                     log.info("[테이블 초기화] 처리 완료 boothId={}, tableNum={}, staffCall취소건수={}",
-                            boothId, dto.getTableNum(), voided.size());
+                            boothId, tableNum, voided.size());
                     return;
                 }
 
@@ -107,6 +120,38 @@ public class ServingTaskEventListener {
                         channel, truncateForLog(message, 4000), e);
             }
         }
+    }
+
+    /** JSON에 table_num 이 문자열 등으로만 있을 때 보조 파싱 */
+    private Integer extractTableNumFromResetJson(String message) {
+        try {
+            JsonNode root = objectMapper.readTree(message);
+            Integer n = readIntFlexible(root.get("table_num"));
+            if (n != null) {
+                return n;
+            }
+            return readIntFlexible(root.get("table_number"));
+        } catch (Exception e) {
+            log.warn("[테이블 초기화] table_num JSON 보조 파싱 실패: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    private static Integer readIntFlexible(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        if (node.isInt() || node.isLong()) {
+            return node.intValue();
+        }
+        if (node.isTextual()) {
+            try {
+                return Integer.parseInt(node.asText().trim());
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
     }
 
     private static String truncateForLog(String s, int maxChars) {

--- a/spring/src/main/resources/application.yml
+++ b/spring/src/main/resources/application.yml
@@ -141,8 +141,8 @@ spring:
 jwt:
   cookie:
     secure: true
-    same-site: "None"    # Django와 동일 (Safari/iOS WebSocket 쿠키 누락 방지) - 따옴표 필수 (YAML에서 None은 null로 파싱됨)
-    domain: .dorder-api.shop  # 모든 서브도메인 쿠키 공유
+    same-site: 'None' # Django와 동일 (Safari/iOS WebSocket 쿠키 누락 방지) - 따옴표 필수 (YAML에서 None은 null로 파싱됨)
+    domain: .dorder-api.shop # 모든 서브도메인 쿠키 공유
 
 # 서버 설정
 server:


### PR DESCRIPTION
Made-with: Cursor

<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->
django:booth:*:order:reset 채널에 테이블 초기화(table_num)와 서빙 취소(order_item_id만 존재) 페이로드가 함께 들어와 Spring에서 동일하게 처리되거나, 테이블 리셋 시 staff_call이 기대대로 정리되지 않는 문제가 있었다.
PostgreSQL staff_call_status_check에 없는 VOIDED_BY_RESET 사용으로 인한 제약 위험도 있어, 상태값과 트랜잭션 경계(테이블 리셋 시 DB 커밋 후 알림/WS), 로그 태그 정리, table_num이 문자열이거나 JSON에만 있을 때 서빙 취소로 오인하지 않도록 order:reset 처리 순서를 보완했다.

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #334
<!-- - ex) #3 -->