### PR TITLE
[Feat] #338 - 주문취소 단일 API 추가

### DIFF
--- a/spring/src/main/java/com/example/spring/controller/staffcall/StaffCallController.java
+++ b/spring/src/main/java/com/example/spring/controller/staffcall/StaffCallController.java
@@ -6,9 +6,11 @@ import com.example.spring.dto.staffcall.request.StaffCallCompleteRequest;
 import com.example.spring.dto.staffcall.request.StaffCallDeleteRequest;
 import com.example.spring.dto.staffcall.request.StaffCallEmitRequest;
 import com.example.spring.dto.staffcall.request.StaffCallListRequest;
+import com.example.spring.dto.staffcall.request.OrderCancelRequest;
 import com.example.spring.dto.staffcall.response.StaffCallAcceptResponse;
 import com.example.spring.security.ServerApiJwtFilter;
 import com.example.spring.service.staffcall.StaffCallConflictException;
+import com.example.spring.service.staffcall.OrderCancelService;
 import com.example.spring.service.staffcall.StaffCallQueryService;
 import com.example.spring.service.staffcall.StaffCallService;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +28,7 @@ public class StaffCallController {
 
     private final StaffCallQueryService staffCallQueryService;
     private final StaffCallService staffCallService;
+    private final OrderCancelService orderCancelService;
 
     /**
      * 직원 호출 발생 — 경로를 {@code /staffcall/{boothId}} 보다 먼저 등록 (request가 boothId로 오인되지 않도록)
@@ -127,6 +130,28 @@ public class StaffCallController {
             Long boothId = (Long) request.getAttribute(ServerApiJwtFilter.ATTR_BOOTH_ID);
             String accessToken = (String) request.getAttribute("ACCESS_TOKEN");
             return ResponseEntity.ok(staffCallService.cancelAccept(boothId, accessToken, body));
+        } catch (StaffCallConflictException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("message", e.getMessage()));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("message", e.getMessage()));
+        }
+    }
+
+    /**
+     * 주문 취소(직원/운영) 단일 API.
+     * - Django 결제취소(payment-cancel) 성공 시에만 staffcall을 삭제하고
+     * - 마지막에 커스터머에게 DELETED를 1회 푸시한다.
+     *
+     * POST /api/v3/spring/server/order/cancel
+     */
+    @PostMapping("/order/cancel")
+    public ResponseEntity<Map<String, Object>> cancelOrder(
+            @RequestBody OrderCancelRequest body,
+            HttpServletRequest request) {
+        try {
+            Long boothId = (Long) request.getAttribute(ServerApiJwtFilter.ATTR_BOOTH_ID);
+            Long staffCallId = body != null ? body.getStaffCallId() : null;
+            return ResponseEntity.ok(orderCancelService.cancelOrder(boothId, staffCallId));
         } catch (StaffCallConflictException e) {
             return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("message", e.getMessage()));
         } catch (IllegalArgumentException e) {

--- a/spring/src/main/java/com/example/spring/dto/staffcall/request/OrderCancelRequest.java
+++ b/spring/src/main/java/com/example/spring/dto/staffcall/request/OrderCancelRequest.java
@@ -1,0 +1,11 @@
+package com.example.spring.dto.staffcall.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OrderCancelRequest {
+    private Long staffCallId;
+}
+

--- a/spring/src/main/java/com/example/spring/service/staffcall/OrderCancelService.java
+++ b/spring/src/main/java/com/example/spring/service/staffcall/OrderCancelService.java
@@ -1,0 +1,155 @@
+package com.example.spring.service.staffcall;
+
+import com.example.spring.config.DjangoApiUtil;
+import com.example.spring.domain.staffcall.StaffCall;
+import com.example.spring.domain.staffcall.StaffCallStatus;
+import com.example.spring.dto.redis.StaffCallRedisMessageDto;
+import com.example.spring.repository.staffcall.StaffCallRepository;
+import com.example.spring.websocket.CustomerStaffCallWebSocketHandler;
+import com.example.spring.websocket.StaffCallWebSocketHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 직원/운영 화면의 "주문 취소"를 단일 API로 처리하기 위한 오케스트레이션 서비스.
+ *
+ * 목표: Django 결제취소 성공 시에만 staffcall을 삭제하고, 마지막에 커스터머 WS로 DELETED를 1회 푸시한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OrderCancelService {
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    private final StaffCallRepository staffCallRepository;
+    private final StaffCallQueryService staffCallQueryService;
+    private final StaffCallWebSocketHandler staffCallWebSocketHandler;
+    private final CustomerStaffCallWebSocketHandler customerStaffCallWebSocketHandler;
+    private final StringRedisTemplate redisTemplate;
+
+    @Value("${django.api.base-url}")
+    private String djangoApiBaseUrl;
+
+    @Transactional
+    public Map<String, Object> cancelOrder(Long boothId, Long staffCallId) {
+        if (boothId == null) {
+            throw new IllegalArgumentException("booth_id를 확인할 수 없습니다.");
+        }
+        if (staffCallId == null) {
+            throw new IllegalArgumentException("staff_call_id는 필수입니다.");
+        }
+
+        StaffCall sc = staffCallRepository.findById(staffCallId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 호출을 찾을 수 없습니다."));
+
+        if (!boothId.equals(sc.getBoothId())) {
+            throw new IllegalArgumentException("부스 정보가 일치하지 않습니다.");
+        }
+
+        if (sc.getTableUsageId() == null) {
+            throw new StaffCallConflictException("table_usage_id가 없어 결제 취소를 진행할 수 없습니다.");
+        }
+
+        if (sc.getStatus() == StaffCallStatus.COMPLETED || sc.getStatus() == StaffCallStatus.CANCELLED) {
+            throw new StaffCallConflictException("이미 처리된 호출입니다.");
+        }
+
+        // 1) Django 결제취소 (실패 시 staffcall은 건드리지 않음)
+        callDjangoPaymentCancel(sc.getTableUsageId());
+
+        // 2) staffcall 정리 (PENDING/ACCEPTED만 삭제 허용)
+        if (sc.getStatus() != StaffCallStatus.PENDING && sc.getStatus() != StaffCallStatus.ACCEPTED) {
+            throw new StaffCallConflictException("취소할 수 없는 staffcall 상태입니다.");
+        }
+
+        staffCallRepository.delete(sc);
+
+        // 3) 이벤트 발행/푸시 (마지막에 DELETED 1회)
+        publishRedis(sc, "staff_call_deleted");
+        try {
+            staffCallWebSocketHandler.broadcastSnapshot(boothId,
+                    staffCallQueryService.listForBooth(boothId, 50, 0));
+            customerStaffCallWebSocketHandler.broadcastDeleted(staffCallId);
+        } catch (Exception e) {
+            log.error("[order cancel] 스냅샷 조회/WS 푸시 실패 — 취소는 반영됨 boothId={}", boothId, e);
+        }
+
+        Map<String, Object> out = new HashMap<>();
+        out.put("message", "주문이 취소되었습니다.");
+        out.put("data", Map.of(
+                "staff_call_id", staffCallId,
+                "table_usage_id", sc.getTableUsageId()
+        ));
+        return out;
+    }
+
+    private void callDjangoPaymentCancel(Long tableUsageId) {
+        String url = djangoApiBaseUrl + "/api/v3/django/cart/payment-cancel/";
+
+        Map<String, String> csrfData = DjangoApiUtil.getCsrfToken(restTemplate, djangoApiBaseUrl);
+        Map<String, Object> requestBody = Map.of("table_usage_id", tableUsageId);
+
+        String jsonBody;
+        try {
+            jsonBody = objectMapper.writeValueAsString(requestBody);
+        } catch (Exception e) {
+            throw new RuntimeException("JSON 변환 실패", e);
+        }
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        if (csrfData.get("csrfToken") != null) headers.set("X-CSRFToken", csrfData.get("csrfToken"));
+        if (csrfData.get("csrfCookie") != null) headers.set(HttpHeaders.COOKIE, csrfData.get("csrfCookie"));
+
+        try {
+            restTemplate.exchange(url, HttpMethod.POST, new HttpEntity<>(jsonBody, headers), Map.class);
+        } catch (HttpClientErrorException e) {
+            // Django 오류 바디를 그대로 전달하는 대신, 현재 서비스 메시지 규칙에 맞춰 변환
+            HttpStatus status = HttpStatus.valueOf(e.getStatusCode().value());
+            if (status == HttpStatus.CONFLICT) {
+                throw new StaffCallConflictException("결제 취소가 가능한 상태가 아닙니다.");
+            }
+            throw new StaffCallConflictException("결제 취소 처리에 실패했습니다.");
+        }
+    }
+
+    private void publishRedis(StaffCall sc, String event) {
+        try {
+            StaffCallRedisMessageDto dto = StaffCallRedisMessageDto.builder()
+                    .event(event)
+                    .staffCallId(sc.getId())
+                    .boothId(sc.getBoothId())
+                    .tableId(sc.getTableId())
+                    .cartId(sc.getCartId())
+                    .tableUsageId(sc.getTableUsageId())
+                    .tableNum(sc.getTableNum())
+                    .cartPrice(sc.getCartPrice())
+                    .callType(sc.getCallType())
+                    .category(sc.getCategory() != null ? sc.getCategory().name() : null)
+                    .status(sc.getStatus() != null ? sc.getStatus().name() : null)
+                    .pushedAt(LocalDateTime.now())
+                    .build();
+
+            String json = objectMapper.writeValueAsString(dto);
+            String channel = "spring:booth:" + sc.getBoothId() + ":staffcall:" + event.replace("staff_call_", "");
+            redisTemplate.convertAndSend(channel, json);
+            log.info("[Redis staffcall] {}", channel);
+        } catch (Exception e) {
+            log.error("[Redis staffcall 발행 실패]", e);
+        }
+    }
+}
+


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->

직원/운영 화면에서 1번 호출로 처리되는 주문취소 단일 API POST /api/v3/spring/server/order/cancel 추가
staff_call_id 기반으로 StaffCall.tableUsageId를 조회해 Django cart/payment-cancel/ 연동(결제취소 → cart ACTIVE 복구)
Django 결제취소 성공 시에만 staffcall DB delete 수행
처리 완료 시 커스터머 WS에 DELETED 1회 푸시 + 직원 WS 스냅샷 갱신


## 📍 PR Point

<!-- 나 이 부분 찢었다~! -->


## 📢 Notices

 <!-- 공용으로 사용하는(Extension) 부분에 대한 설명 -->

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #
<!-- - ex) #3 -->