### PR TITLE
🐛 [Fix] - 테이블 입장 API 동시 호출 시 TableUsage 중복 생성 문제

### DIFF
--- a/django/table/services.py
+++ b/django/table/services.py
@@ -213,8 +213,9 @@ class TableService:
         if not table_num:
             raise ValidationError('테이블 번호는 필수입니다.')
 
-        # 테이블 조회
-        table = Table.objects.select_related('group__representative_table').filter(
+        # 테이블 조회 (행 잠금: 동시 입장 요청 시 TOCTOU 경합 방지)
+        # of=('self',): nullable outer join 대상 제외, Table 행만 잠금
+        table = Table.objects.select_related('group__representative_table').select_for_update(of=('self',)).filter(
             booth=booth, table_num=table_num
         ).first()
         if not table:
@@ -224,8 +225,13 @@ class TableService:
         if table.status == Table.Status.INACTIVE:
             raise ValidationError('해당 테이블은 현재 이용할 수 없습니다.')
 
-        # 병합된 테이블이면 대표 테이블 기준으로 처리
-        representative_table = table.group.representative_table if table.group else table
+        # 병합된 테이블이면 대표 테이블 기준으로 처리 (대표 테이블도 잠금)
+        if table.group:
+            representative_table = Table.objects.select_for_update().get(
+                pk=table.group.representative_table_id
+            )
+        else:
+            representative_table = table
 
         # 이미 사용 중인 경우 대표 테이블의 기존 세션 반환
         if table.status == Table.Status.IN_USE:

--- a/django/table/tests.py
+++ b/django/table/tests.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 from datetime import timedelta
 from django.test import override_settings, TransactionTestCase, TestCase
 from rest_framework.test import APITestCase, APIClient
@@ -1234,3 +1235,74 @@ class MergeActiveUsagesTestCase(TestCase):
         order.refresh_from_db()
         rep_cart = Cart.objects.get(table_usage=self._rep_usage(self.t1))
         self.assertEqual(order.cart, rep_cart)
+
+
+@override_settings(STORAGES=IN_MEMORY_STORAGES)
+class TableConcurrentEnterTestCase(TransactionTestCase):
+    """테이블 입장 동시 호출 시 TableUsage 중복 생성 방지 테스트"""
+
+    def setUp(self):
+        client = APIClient()
+        client.post(SIGNUP_URL, VALID_SIGNUP_DATA, format='json')
+        self.user = User.objects.get(username='testuser')
+        self.booth = Booth.objects.get(user=self.user)
+
+    def test_동시_입장_2개_요청시_TableUsage_하나만_생성(self):
+        """동시에 같은 테이블에 2개 입장 요청이 들어와도 TableUsage가 1개만 생성되어야 한다"""
+        results = []
+        errors = []
+        barrier = threading.Barrier(2)
+
+        def enter():
+            try:
+                barrier.wait()
+                usage = TableService.init_or_enter_table(self.booth, 1)
+                results.append(usage.id)
+            except Exception as e:
+                errors.append(e)
+
+        t1 = threading.Thread(target=enter)
+        t2 = threading.Thread(target=enter)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        self.assertEqual(len(errors), 0, f"예외 발생: {errors}")
+        active_usages = TableUsage.objects.filter(
+            table__booth=self.booth,
+            table__table_num=1,
+            ended_at__isnull=True,
+        )
+        self.assertEqual(active_usages.count(), 1, "TableUsage가 1개여야 합니다")
+        self.assertEqual(results[0], results[1], "두 요청이 같은 TableUsage를 반환해야 합니다")
+
+    def test_동시_입장_5개_요청시_TableUsage_하나만_생성(self):
+        """5개 동시 요청에도 TableUsage가 1개만 생성되어야 한다"""
+        results = []
+        errors = []
+        n = 5
+        barrier = threading.Barrier(n)
+
+        def enter():
+            try:
+                barrier.wait()
+                usage = TableService.init_or_enter_table(self.booth, 2)
+                results.append(usage.id)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=enter) for _ in range(n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(len(errors), 0, f"예외 발생: {errors}")
+        active_usages = TableUsage.objects.filter(
+            table__booth=self.booth,
+            table__table_num=2,
+            ended_at__isnull=True,
+        )
+        self.assertEqual(active_usages.count(), 1, "TableUsage가 1개여야 합니다")
+        self.assertEqual(len(set(results)), 1, "모든 요청이 같은 TableUsage를 반환해야 합니다")


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

- 동일 테이블에 입장 API를 동시에 여러 번 호출하면 `ended_at=NULL`인 `TableUsage`가 중복 생성되는 버그 수정
- `select_for_update(of=('self',))`로 Table 행에 배타적 잠금을 적용하여 TOCTOU 경합 방지
- 동시성 테스트 케이스 추가

## 📍 PR Point

- `init_or_enter_table`의 Table 조회에 `select_for_update(of=('self',))` 추가
  - `of=('self',)`: nullable outer join(`group`) 대상을 잠금에서 제외하여 PostgreSQL 오류 방지
  - 잠금은 `(booth_id, table_num)` 조건에 매칭된 단일 행에만 적용되므로 다른 테이블 입장에 영향 없음
- `TableConcurrentEnterTestCase` 추가 (`TransactionTestCase` + `threading.Barrier`)
  - 동시 2개 요청, 동시 5개 요청 시나리오 검증

## 📢 Notices

없음

## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

- #342