### PR TITLE
✨[Feat] - jwt payload에 사용자를 구분하기 위한 uuid 추가

### DIFF
--- a/spring/src/main/java/com/example/spring/config/JwtUtil.java
+++ b/spring/src/main/java/com/example/spring/config/JwtUtil.java
@@ -158,6 +158,15 @@ public class JwtUtil {
     }
 
     /**
+     * Django session_id custom claim 추출 (UUID 문자열, 없으면 null)
+     */
+    public String getSessionIdFromToken(String token) {
+        Claims claims = parseClaims(token);
+        Object sessionId = claims.get("session_id");
+        return sessionId != null ? sessionId.toString() : null;
+    }
+
+    /**
      * 토큰 유효성 검증
      */
     public boolean validateToken(String token) {

--- a/spring/src/main/java/com/example/spring/config/StaffCallHandshakeInterceptor.java
+++ b/spring/src/main/java/com/example/spring/config/StaffCallHandshakeInterceptor.java
@@ -13,13 +13,14 @@ import org.springframework.web.socket.server.HandshakeInterceptor;
 import java.util.Map;
 
 /**
- * 웹소켓 핸드셰이크 시 access_token 쿠키로 booth_id 확보
+ * 웹소켓 핸드셰이크 시 access_token 쿠키로 booth_id 및 session_id 확보
  */
 @Component
 @RequiredArgsConstructor
 public class StaffCallHandshakeInterceptor implements HandshakeInterceptor {
 
     public static final String ATTR_BOOTH_ID = "boothId";
+    public static final String ATTR_SESSION_ID = "sessionId";
 
     private final CookieUtil cookieUtil;
     private final JwtUtil jwtUtil;
@@ -39,6 +40,7 @@ public class StaffCallHandshakeInterceptor implements HandshakeInterceptor {
         try {
             Long boothId = jwtUtil.getBoothIdFromToken(token);
             attributes.put(ATTR_BOOTH_ID, boothId);
+            attributes.put(ATTR_SESSION_ID, jwtUtil.getSessionIdFromToken(token));
             return true;
         } catch (Exception e) {
             return false;

--- a/spring/src/main/java/com/example/spring/controller/staffcall/StaffCallController.java
+++ b/spring/src/main/java/com/example/spring/controller/staffcall/StaffCallController.java
@@ -22,7 +22,7 @@ import jakarta.servlet.http.HttpServletRequest;
 @RestController
 @RequestMapping("/server")
 @RequiredArgsConstructor
-public class StaffCallController {
+public class  StaffCallController {
 
     private final StaffCallQueryService staffCallQueryService;
     private final StaffCallService staffCallService;
@@ -86,7 +86,8 @@ public class StaffCallController {
         try {
             Long boothId = (Long) request.getAttribute(ServerApiJwtFilter.ATTR_BOOTH_ID);
             String accessToken = (String) request.getAttribute("ACCESS_TOKEN");
-            StaffCallAcceptResponse data = staffCallService.accept(boothId, accessToken, body);
+            String sessionId = (String) request.getAttribute(ServerApiJwtFilter.ATTR_SESSION_ID);
+            StaffCallAcceptResponse data = staffCallService.accept(boothId, accessToken, sessionId, body);
             return ResponseEntity.ok(Map.of(
                     "message", "호출을 수락했습니다.",
                     "data", data

--- a/spring/src/main/java/com/example/spring/domain/staffcall/StaffCall.java
+++ b/spring/src/main/java/com/example/spring/domain/staffcall/StaffCall.java
@@ -64,6 +64,9 @@ public class StaffCall {
     @Column(name = "completed_at")
     private LocalDateTime completedAt;
 
+    @Column(name = "locked_by_session_id", length = 36)
+    private String lockedBySessionId;
+
     @Version
     @Column(name = "version")
     private Long version;
@@ -84,10 +87,11 @@ public class StaffCall {
         this.updatedAt = this.createdAt;
     }
 
-    public void accept(String acceptedBy) {
+    public void accept(String acceptedBy, String sessionId) {
         this.status = StaffCallStatus.ACCEPTED;
         this.acceptedAt = LocalDateTime.now();
         this.acceptedBy = acceptedBy;
+        this.lockedBySessionId = sessionId;
         this.updatedAt = this.acceptedAt;
     }
 
@@ -95,6 +99,7 @@ public class StaffCall {
         this.status = StaffCallStatus.PENDING;
         this.acceptedAt = null;
         this.acceptedBy = null;
+        this.lockedBySessionId = null;
         this.updatedAt = LocalDateTime.now();
     }
 

--- a/spring/src/main/java/com/example/spring/repository/staffcall/StaffCallRepository.java
+++ b/spring/src/main/java/com/example/spring/repository/staffcall/StaffCallRepository.java
@@ -22,10 +22,12 @@ public interface StaffCallRepository extends JpaRepository<StaffCall, Long> {
             @Param("callType") String callType
     );
 
+    List<StaffCall> findByLockedBySessionIdAndStatus(String lockedBySessionId, StaffCallStatus status);
+
     @Query(value = """
             SELECT sc.id, sc.booth_id, sc.table_id, sc.cart_id, sc.table_usage_id, sc.table_num, sc.cart_price,
                    sc.call_type, sc.category,
-                   sc.status, sc.created_at, sc.updated_at, sc.accepted_at, sc.accepted_by, sc.completed_at, sc.version
+                   sc.status, sc.created_at, sc.updated_at, sc.accepted_at, sc.accepted_by, sc.completed_at, sc.version, sc.locked_by_session_id
             FROM staff_call sc
             WHERE sc.booth_id = :boothId
             AND sc.status IN ('PENDING', 'ACCEPTED')

--- a/spring/src/main/java/com/example/spring/security/ServerApiJwtFilter.java
+++ b/spring/src/main/java/com/example/spring/security/ServerApiJwtFilter.java
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 public class ServerApiJwtFilter extends OncePerRequestFilter {
 
     public static final String ATTR_BOOTH_ID = "BOOTH_ID";
+    public static final String ATTR_SESSION_ID = "SESSION_ID";
 
     private final CookieUtil cookieUtil;
     private final JwtUtil jwtUtil;
@@ -62,7 +63,9 @@ public class ServerApiJwtFilter extends OncePerRequestFilter {
 
         try {
             Long boothId = jwtUtil.getBoothIdFromToken(token);
+            String sessionId = jwtUtil.getSessionIdFromToken(token);
             request.setAttribute(ATTR_BOOTH_ID, boothId);
+            request.setAttribute(ATTR_SESSION_ID, sessionId);
             request.setAttribute("ACCESS_TOKEN", token);
         } catch (Exception e) {
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);

--- a/spring/src/main/java/com/example/spring/service/staffcall/StaffCallService.java
+++ b/spring/src/main/java/com/example/spring/service/staffcall/StaffCallService.java
@@ -57,7 +57,7 @@ public class StaffCallService {
     private CustomerStaffCallWebSocketHandler customerStaffCallWebSocketHandler;
 
     @Transactional
-    public StaffCallAcceptResponse accept(Long boothId, String accessToken, StaffCallAcceptRequest req) {
+    public StaffCallAcceptResponse accept(Long boothId, String accessToken, String sessionId, StaffCallAcceptRequest req) {
         if (req.getTableId() == null || req.getCartId() == null || req.getCallType() == null) {
             throw new IllegalArgumentException("table_id, cart_id, call_type은 필수입니다.");
         }
@@ -82,7 +82,7 @@ public class StaffCallService {
             acceptedBy = "unknown";
         }
 
-        sc.accept(acceptedBy);
+        sc.accept(acceptedBy, sessionId);
 
         publishRedis(sc, "staff_call_accepted");
         try {
@@ -141,6 +141,22 @@ public class StaffCallService {
         out.put("message", "호출 수락을 취소했습니다.");
         out.put("data", StaffCallItemResponse.from(sc));
         return out;
+    }
+
+    @Transactional
+    public void releaseBySessionId(String sessionId) {
+        List<StaffCall> locked = staffCallRepository.findByLockedBySessionIdAndStatus(sessionId, StaffCallStatus.ACCEPTED);
+        for (StaffCall sc : locked) {
+            sc.unaccept();
+            publishRedis(sc, "staff_call_unaccepted");
+            try {
+                staffCallWebSocketHandler.broadcastSnapshot(sc.getBoothId(),
+                        staffCallQueryService.listForBooth(sc.getBoothId(), 50, 0));
+                customerStaffCallWebSocketHandler.broadcastStatus(sc);
+            } catch (Exception e) {
+                log.error("[staffcall release] broadcast 실패 sessionId={}", sessionId, e);
+            }
+        }
     }
 
     @Transactional

--- a/spring/src/main/java/com/example/spring/websocket/StaffCallWebSocketHandler.java
+++ b/spring/src/main/java/com/example/spring/websocket/StaffCallWebSocketHandler.java
@@ -1,10 +1,13 @@
 package com.example.spring.websocket;
 
 import com.example.spring.service.staffcall.StaffCallQueryService;
+import com.example.spring.service.staffcall.StaffCallService;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
@@ -18,6 +21,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static com.example.spring.config.StaffCallHandshakeInterceptor.ATTR_BOOTH_ID;
+import static com.example.spring.config.StaffCallHandshakeInterceptor.ATTR_SESSION_ID;
 
 /**
  * 부스 단위 직원 호출 목록 — LIST 요청 및 서버 푸시(STAFF_CALL_SNAPSHOT)
@@ -29,6 +33,10 @@ public class StaffCallWebSocketHandler extends TextWebSocketHandler {
 
     private final StaffCallQueryService staffCallQueryService;
     private final ObjectMapper objectMapper;
+
+    @Lazy
+    @Autowired
+    private StaffCallService staffCallService;
 
     private final Map<Long, Set<WebSocketSession>> boothSessions = new ConcurrentHashMap<>();
 
@@ -49,6 +57,7 @@ public class StaffCallWebSocketHandler extends TextWebSocketHandler {
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
         Long boothId = (Long) session.getAttributes().get(ATTR_BOOTH_ID);
+        String sessionId = (String) session.getAttributes().get(ATTR_SESSION_ID);
         if (boothId != null) {
             Set<WebSocketSession> set = boothSessions.get(boothId);
             if (set != null) {
@@ -56,6 +65,13 @@ public class StaffCallWebSocketHandler extends TextWebSocketHandler {
                 if (set.isEmpty()) {
                     boothSessions.remove(boothId);
                 }
+            }
+        }
+        if (sessionId != null) {
+            try {
+                staffCallService.releaseBySessionId(sessionId);
+            } catch (Exception e) {
+                log.error("[staffcall ws] disconnect 자동 해제 실패 sessionId={}", sessionId, e);
             }
         }
     }


### PR DESCRIPTION
## 🔍 What is the PR?
여러 직원이 하나의 부스 계정을 공유하는 환경에서, 직원이 staff_call을 수락한 뒤 페이지를 새로고침하면 WebSocket 세션이 끊기면서 해당 콜이 영구적으로 ACCEPTED 상태로 잠기는 문제를 해결합니다.

JWT payload에 `session_id`(UUID)를 추가하고, 이를 기반으로 WebSocket 세션 종료 시 해당 직원이 잡고 있던 staff_call을 자동으로 PENDING으로 복구합니다.

## 📍 PR Point

**Django (feat/#229)**
- 로그인/회원가입 시 발급되는 JWT payload에 `session_id` (UUID v4) custom claim 추가

**Spring**
- `JwtUtil`: `getSessionIdFromToken()` 메서드 추가
- `ServerApiJwtFilter`: JWT에서 `session_id` 추출 → `SESSION_ID` request attribute 세팅
- `StaffCallHandshakeInterceptor`: WebSocket 핸드셰이크 시 `session_id` → `sessionId` attribute 세팅
- `StaffCall`: `locked_by_session_id` 컬럼 추가 — accept 시 저장, unaccept 시 초기화
- `StaffCallRepository`: `findByLockedBySessionIdAndStatus()` 쿼리 추가
- `StaffCallService`: `accept()`에 sessionId 저장, `releaseBySessionId()` 메서드 신규 추가
- `StaffCallWebSocketHandler`: `afterConnectionClosed()` 시 `releaseBySessionId()` 호출 → 자동 PENDING 복구

## 🔁 동작 흐름

```
직원 A (session=X) → /server/accept 호출 → StaffCall.locked_by_session_id = X
직원 A 새로고침   → WebSocket 끊김 → afterConnectionClosed
                                    → releaseBySessionId("X")
                                    → ACCEPTED → PENDING 자동 복구
                                    → 전체 직원 화면 WebSocket 브로드캐스트
직원 A 재접속 (session=Y) → 콜이 PENDING 상태로 목록에 표시됨
```

## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

- #229