### PR TITLE
✨ [Feat] : 필터링 기능 (메뉴, 테이블 번호) 불러오기 API 추가

### DIFF
--- a/spring/src/main/java/com/example/spring/controller/serving/ServingTaskController.java
+++ b/spring/src/main/java/com/example/spring/controller/serving/ServingTaskController.java
@@ -13,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/serving")
@@ -67,20 +68,25 @@ public class ServingTaskController {
 
 
     @GetMapping("/filter-options")
-    public ResponseEntity<ServingFilterOptionsResponse> getFilterOptions(HttpServletRequest request) {
+    public ResponseEntity<?> getFilterOptions(HttpServletRequest request) {
         Long boothId = (Long) request.getAttribute(ServerApiJwtFilter.ATTR_BOOTH_ID);
+        String accessToken = (String) request.getAttribute("ACCESS_TOKEN");
 
-        if (boothId == null) {
+        if (boothId == null || accessToken == null || accessToken.isBlank()) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 
-        ServingFilterOptionsData data = servingTaskService.getFilterOptions(boothId);
-        ServingFilterOptionsResponse response = ServingFilterOptionsResponse.builder()
-                .message("서빙 필터 옵션 조회 완료")
-                .data(data)
-                .build();
-
-        return ResponseEntity.ok(response);
+        try {
+            ServingFilterOptionsData data = servingTaskService.getFilterOptions(boothId, accessToken);
+            ServingFilterOptionsResponse response = ServingFilterOptionsResponse.builder()
+                    .message("서빙 필터 옵션 조회 완료")
+                    .data(data)
+                    .build();
+            return ResponseEntity.ok(response);
+        } catch (ServingTaskService.DjangoApiException e) {
+            return ResponseEntity.status(e.getStatus())
+                    .body(Map.of("message", "서빙 필터 옵션 조회 실패", "detail", e.getResponseBody()));
+        }
     }
 
     @PostMapping("/catchcall")

--- a/spring/src/main/java/com/example/spring/controller/serving/ServingTaskController.java
+++ b/spring/src/main/java/com/example/spring/controller/serving/ServingTaskController.java
@@ -1,6 +1,8 @@
 package com.example.spring.controller.serving;
 
 import com.example.spring.domain.serving.ServingTask;
+import com.example.spring.dto.serving.response.ServingFilterOptionsData;
+import com.example.spring.dto.serving.response.ServingFilterOptionsResponse;
 import com.example.spring.dto.serving.response.ServingTaskResponse;
 import com.example.spring.security.ServerApiJwtFilter;
 import com.example.spring.service.serving.ServingTaskService;
@@ -59,6 +61,24 @@ public class ServingTaskController {
         List<ServingTaskResponse> response = tasks.stream()
                 .map(ServingTaskResponse::from)
                 .toList();
+
+        return ResponseEntity.ok(response);
+    }
+
+
+    @GetMapping("/filter-options")
+    public ResponseEntity<ServingFilterOptionsResponse> getFilterOptions(HttpServletRequest request) {
+        Long boothId = (Long) request.getAttribute(ServerApiJwtFilter.ATTR_BOOTH_ID);
+
+        if (boothId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        ServingFilterOptionsData data = servingTaskService.getFilterOptions(boothId);
+        ServingFilterOptionsResponse response = ServingFilterOptionsResponse.builder()
+                .message("서빙 필터 옵션 조회 완료")
+                .data(data)
+                .build();
 
         return ResponseEntity.ok(response);
     }

--- a/spring/src/main/java/com/example/spring/domain/serving/ServingTask.java
+++ b/spring/src/main/java/com/example/spring/domain/serving/ServingTask.java
@@ -24,6 +24,12 @@ public class ServingTask {
     @Column(name = "table_number")
     private Integer tableNumber;
 
+    @Column(name = "menu_name")
+    private String menuName;
+
+    @Column(name = "quantity")
+    private Integer quantity;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "status")
     private ServingStatus status;
@@ -43,22 +49,22 @@ public class ServingTask {
     @Column(name = "served_at")
     private LocalDateTime servedAt;
 
-    // 🌟 catchedBy 필드 삭제됨
-
     @Column(name = "key", nullable = false, length = 255)
     private String key;
 
     @Builder
-    public ServingTask(Long boothId, Long orderItemId, Integer tableNumber, String key) {        this.boothId = boothId;
+    public ServingTask(Long boothId, Long orderItemId, Integer tableNumber, String menuName, Integer quantity, String key) {
+        this.boothId = boothId;
         this.orderItemId = orderItemId;
         this.tableNumber = tableNumber;
+        this.menuName = menuName;
+        this.quantity = quantity;
         this.status = ServingStatus.SERVE_REQUESTED;
         this.key = key;
         this.createdAt = LocalDateTime.now();
         this.requestedAt = LocalDateTime.now();
     }
 
-    // 🌟 파라미터 catchedBy 제거
     public void acceptServing() {
         this.status = ServingStatus.SERVING;
         this.catchedAt = LocalDateTime.now();
@@ -73,7 +79,6 @@ public class ServingTask {
 
     public void cancelServing() {
         this.status = ServingStatus.SERVE_REQUESTED;
-        // 🌟 catchedBy = null; 삭제됨
         this.catchedAt = null;
         this.updatedAt = LocalDateTime.now();
     }

--- a/spring/src/main/java/com/example/spring/dto/serving/django/DjangoAdminMenuListResponse.java
+++ b/spring/src/main/java/com/example/spring/dto/serving/django/DjangoAdminMenuListResponse.java
@@ -1,0 +1,47 @@
+package com.example.spring.dto.serving.django;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class DjangoAdminMenuListResponse {
+    private String message;
+
+    @JsonProperty("booth_id")
+    private Long boothId;
+
+    private List<MenuItem> data;
+
+    @Getter
+    @NoArgsConstructor
+    public static class MenuItem {
+        private Long id;
+        private String name;
+        private String category;
+
+        @JsonProperty("is_soldout")
+        private Boolean isSoldout;
+
+        @JsonProperty("is_fixed")
+        private Boolean isFixed;
+
+        @JsonProperty("set_items")
+        private List<SetItem> setItems;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class SetItem {
+        @JsonProperty("menu_id")
+        private Long menuId;
+        private Integer quantity;
+
+        @JsonProperty("base_price")
+        private Integer basePrice;
+        private Integer stock;
+    }
+}

--- a/spring/src/main/java/com/example/spring/dto/serving/django/DjangoBoothMypageResponse.java
+++ b/spring/src/main/java/com/example/spring/dto/serving/django/DjangoBoothMypageResponse.java
@@ -1,0 +1,19 @@
+package com.example.spring.dto.serving.django;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DjangoBoothMypageResponse {
+    private String message;
+    private MypageData data;
+
+    @Getter
+    @NoArgsConstructor
+    public static class MypageData {
+        @JsonProperty("table_max_cnt")
+        private Integer tableMaxCnt;
+    }
+}

--- a/spring/src/main/java/com/example/spring/dto/serving/response/ServingFilterOptionsData.java
+++ b/spring/src/main/java/com/example/spring/dto/serving/response/ServingFilterOptionsData.java
@@ -1,0 +1,13 @@
+package com.example.spring.dto.serving.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ServingFilterOptionsData {
+    private List<ServingMenuFilterOption> menus;
+    private List<Integer> tables;
+}

--- a/spring/src/main/java/com/example/spring/dto/serving/response/ServingFilterOptionsData.java
+++ b/spring/src/main/java/com/example/spring/dto/serving/response/ServingFilterOptionsData.java
@@ -9,5 +9,6 @@ import java.util.List;
 @AllArgsConstructor
 public class ServingFilterOptionsData {
     private List<ServingMenuFilterOption> menus;
+    private Integer tableCount;
     private List<Integer> tables;
 }

--- a/spring/src/main/java/com/example/spring/dto/serving/response/ServingFilterOptionsResponse.java
+++ b/spring/src/main/java/com/example/spring/dto/serving/response/ServingFilterOptionsResponse.java
@@ -1,0 +1,13 @@
+package com.example.spring.dto.serving.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ServingFilterOptionsResponse {
+    private String message;
+    private ServingFilterOptionsData data;
+}

--- a/spring/src/main/java/com/example/spring/dto/serving/response/ServingMenuFilterOption.java
+++ b/spring/src/main/java/com/example/spring/dto/serving/response/ServingMenuFilterOption.java
@@ -6,6 +6,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class ServingMenuFilterOption {
-    private String id;
+    private Long id;
     private String name;
 }

--- a/spring/src/main/java/com/example/spring/dto/serving/response/ServingMenuFilterOption.java
+++ b/spring/src/main/java/com/example/spring/dto/serving/response/ServingMenuFilterOption.java
@@ -1,0 +1,11 @@
+package com.example.spring.dto.serving.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ServingMenuFilterOption {
+    private String id;
+    private String name;
+}

--- a/spring/src/main/java/com/example/spring/repository/serving/ServingTaskRepository.java
+++ b/spring/src/main/java/com/example/spring/repository/serving/ServingTaskRepository.java
@@ -3,8 +3,6 @@ package com.example.spring.repository.serving;
 import com.example.spring.domain.serving.ServingStatus;
 import com.example.spring.domain.serving.ServingTask;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -22,25 +20,4 @@ public interface ServingTaskRepository extends JpaRepository<ServingTask, Long> 
     long deleteByBoothIdAndOrderItemIdAndStatusIn(Long boothId, Long orderItemId, List<ServingStatus> statuses);
 
     long deleteByBoothIdAndTableNumberAndStatusIn(Long boothId, Integer tableNumber, List<ServingStatus> statuses);
-
-    @Query("""
-            select distinct st.menuName
-            from ServingTask st
-            where st.boothId = :boothId
-              and st.status = :status
-              and st.menuName is not null
-            order by st.menuName asc
-            """)
-    List<String> findDistinctMenuNamesByBoothIdAndStatus(@Param("boothId") Long boothId, @Param("status") ServingStatus status);
-
-    @Query("""
-            select distinct st.tableNumber
-            from ServingTask st
-            where st.boothId = :boothId
-              and st.status = :status
-              and st.tableNumber is not null
-            order by st.tableNumber asc
-            """)
-    List<Integer> findDistinctTableNumbersByBoothIdAndStatus(@Param("boothId") Long boothId, @Param("status") ServingStatus status);
-
 }

--- a/spring/src/main/java/com/example/spring/repository/serving/ServingTaskRepository.java
+++ b/spring/src/main/java/com/example/spring/repository/serving/ServingTaskRepository.java
@@ -3,6 +3,8 @@ package com.example.spring.repository.serving;
 import com.example.spring.domain.serving.ServingStatus;
 import com.example.spring.domain.serving.ServingTask;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -20,4 +22,25 @@ public interface ServingTaskRepository extends JpaRepository<ServingTask, Long> 
     long deleteByBoothIdAndOrderItemIdAndStatusIn(Long boothId, Long orderItemId, List<ServingStatus> statuses);
 
     long deleteByBoothIdAndTableNumberAndStatusIn(Long boothId, Integer tableNumber, List<ServingStatus> statuses);
+
+    @Query("""
+            select distinct st.menuName
+            from ServingTask st
+            where st.boothId = :boothId
+              and st.status = :status
+              and st.menuName is not null
+            order by st.menuName asc
+            """)
+    List<String> findDistinctMenuNamesByBoothIdAndStatus(@Param("boothId") Long boothId, @Param("status") ServingStatus status);
+
+    @Query("""
+            select distinct st.tableNumber
+            from ServingTask st
+            where st.boothId = :boothId
+              and st.status = :status
+              and st.tableNumber is not null
+            order by st.tableNumber asc
+            """)
+    List<Integer> findDistinctTableNumbersByBoothIdAndStatus(@Param("boothId") Long boothId, @Param("status") ServingStatus status);
+
 }

--- a/spring/src/main/java/com/example/spring/service/serving/ServingTaskEventListener.java
+++ b/spring/src/main/java/com/example/spring/service/serving/ServingTaskEventListener.java
@@ -2,10 +2,6 @@ package com.example.spring.service.serving;
 
 import com.example.spring.dto.redis.OrderCookedMessageDto;
 import com.example.spring.event.RedisMessageEvent;
-import com.example.spring.domain.staffcall.StaffCall;
-import com.example.spring.service.staffcall.StaffCallTableResetService;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,7 +9,6 @@ import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.UUID;
 
 @Slf4j
@@ -22,7 +17,6 @@ import java.util.UUID;
 public class ServingTaskEventListener {
 
     private final ServingTaskService servingTaskService;
-    private final StaffCallTableResetService staffCallTableResetService;
     private final ObjectMapper objectMapper;
 
     @EventListener
@@ -35,12 +29,7 @@ public class ServingTaskEventListener {
             try {
                 Long boothId = extractBoothId(channel);
                 String orderEvent = extractOrderEvent(channel);
-                log.info("[Redis 주문] 수신 boothId={}, 이벤트={}, channel={}, message={}",
-                        boothId, orderEvent, channel, truncateForLog(message, 4000));
-
                 OrderCookedMessageDto dto = objectMapper.readValue(message, OrderCookedMessageDto.class);
-                log.info("[Redis 주문] JSON 파싱 완료 tableNum={}, orderItemId={}",
-                        dto.getTableNum(), dto.getOrderItemId());
 
                 if ("cooked".equals(orderEvent)) {
                     if (dto.getOrderItemId() == null) {
@@ -54,6 +43,8 @@ public class ServingTaskEventListener {
                             boothId,
                             dto.getOrderItemId(),
                             dto.getTableNum(),
+                            dto.getMenuName(),
+                            dto.getQuantity(),
                             UUID.randomUUID().toString()
                     );
                     log.info("[서빙 태스크 생성 완료] boothId={}, orderItemId={}", boothId, dto.getOrderItemId());
@@ -79,89 +70,17 @@ public class ServingTaskEventListener {
                 }
 
                 if ("reset".equals(orderEvent)) {
-                    /*
-                     * 같은 채널 django:booth:*:order:reset 에 (1) 테이블 초기화용 {"table_num":n}
-                     * (2) 서빙취소용 {"order_item_id":...} 가 함께 온다. (2)는 Spring 테이블 초기화와 무관.
-                     * table_num 이 문자열이면 DTO Integer 가 null 일 수 있어 JSON 보조 파싱을 먼저 한다.
-                     */
-                    Integer tableNumFromJson = extractTableNumFromResetJson(message);
-                    if (dto.getOrderItemId() != null && dto.getTableNum() == null && tableNumFromJson == null) {
-                        log.info("[Redis 주문] order:reset — 테이블 초기화 페이로드 아님(서빙 취소 등) boothId={}, orderItemId={}, 건너뜀",
-                                boothId, dto.getOrderItemId());
+                    if (dto.getTableNum() == null) {
+                        log.warn("[reset 처리 스킵] table_num/table_number 누락. channel={}, message={}", channel, message);
                         return;
                     }
-                    Integer tableNum = dto.getTableNum() != null ? dto.getTableNum() : tableNumFromJson;
-                    if (tableNum == null) {
-                        log.warn("[테이블 초기화 처리 스킵] table_num 없음·파싱 불가. channel={}, message={}",
-                                channel, truncateForLog(message, 2000));
-                        return;
-                    }
-                    log.info("[테이블 초기화] 서빙태스크 삭제 직전 boothId={}, tableNum={}", boothId, tableNum);
-                    servingTaskService.removeTasksByTableNumber(boothId, tableNum, "TABLE_RESET");
-                    log.info("[테이블 초기화] staff_call 취소 호출 직전 boothId={}, tableNum={}", boothId, tableNum);
-                    List<StaffCall> voided = staffCallTableResetService.voidActiveCallsForTable(
-                            boothId, tableNum);
-                    log.info("[테이블 초기화] 스냅샷·WS 호출 직전 boothId={}, staffCall취소건수={}",
-                            boothId, voided.size());
-                    staffCallTableResetService.publishTableResetNotifications(boothId, voided);
-                    log.info("[테이블 초기화] 처리 완료 boothId={}, tableNum={}, staffCall취소건수={}",
-                            boothId, tableNum, voided.size());
-                    return;
+                    servingTaskService.removeTasksByTableNumber(boothId, dto.getTableNum(), "TABLE_RESET");
                 }
 
-                log.warn("[Redis 주문] 미처리 이벤트 이벤트={}, boothId={}, channel={}, message={}",
-                        orderEvent, boothId, channel, truncateForLog(message, 1000));
-
-            } catch (JsonProcessingException e) {
-                log.error("[Redis 주문] JSON 파싱 실패 channel={}, message={}",
-                        channel, truncateForLog(message, 4000), e);
             } catch (Exception e) {
-                log.error("[Redis 주문] 처리 실패 channel={}, message={}",
-                        channel, truncateForLog(message, 4000), e);
+                log.error("[Redis 메시지 처리 실패] channel={}, message={}", channel, message, e);
             }
         }
-    }
-
-    /** JSON에 table_num 이 문자열 등으로만 있을 때 보조 파싱 */
-    private Integer extractTableNumFromResetJson(String message) {
-        try {
-            JsonNode root = objectMapper.readTree(message);
-            Integer n = readIntFlexible(root.get("table_num"));
-            if (n != null) {
-                return n;
-            }
-            return readIntFlexible(root.get("table_number"));
-        } catch (Exception e) {
-            log.warn("[테이블 초기화] table_num JSON 보조 파싱 실패: {}", e.getMessage());
-            return null;
-        }
-    }
-
-    private static Integer readIntFlexible(JsonNode node) {
-        if (node == null || node.isNull()) {
-            return null;
-        }
-        if (node.isInt() || node.isLong()) {
-            return node.intValue();
-        }
-        if (node.isTextual()) {
-            try {
-                return Integer.parseInt(node.asText().trim());
-            } catch (NumberFormatException ignored) {
-                return null;
-            }
-        }
-        return null;
-    }
-
-    private static String truncateForLog(String s, int maxChars) {
-        if (s == null) {
-            return "null";
-        }
-        if (s.length() <= maxChars) {
-            return s;
-        }
-        return s.substring(0, maxChars) + "…(truncated " + s.length() + " chars)";
     }
 
     /**

--- a/spring/src/main/java/com/example/spring/service/serving/ServingTaskService.java
+++ b/spring/src/main/java/com/example/spring/service/serving/ServingTaskService.java
@@ -1,8 +1,11 @@
 package com.example.spring.service.serving;
 
+import com.example.spring.config.DjangoApiUtil;
 import com.example.spring.domain.serving.ServingStatus;
 import com.example.spring.domain.serving.ServingTask;
 import com.example.spring.dto.redis.ServingStatusMessageDto;
+import com.example.spring.dto.serving.django.DjangoAdminMenuListResponse;
+import com.example.spring.dto.serving.django.DjangoBoothMypageResponse;
 import com.example.spring.dto.serving.response.ServingFilterOptionsData;
 import com.example.spring.dto.serving.response.ServingMenuFilterOption;
 import com.example.spring.dto.serving.response.ServingTaskResponse;
@@ -11,11 +14,16 @@ import com.example.spring.websocket.ServingWebSocketHandler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
 
-import java.time.OffsetDateTime; // 🌟 LocalDateTime -> OffsetDateTime 으로 변경
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +43,24 @@ public class ServingTaskService {
     private final StringRedisTemplate redisTemplate;
     private final ObjectMapper objectMapper;
     private final ServingWebSocketHandler webSocketHandler;
+    private final RestTemplate restTemplate;
+
+    @Value("${django.api.base-url}")
+    private String djangoApiBaseUrl;
+
+    public static class DjangoApiException extends RuntimeException {
+        private final HttpStatus status;
+        private final String responseBody;
+
+        public DjangoApiException(HttpStatus status, String responseBody) {
+            super("Django API Error: " + status);
+            this.status = status;
+            this.responseBody = responseBody;
+        }
+
+        public HttpStatus getStatus() { return status; }
+        public String getResponseBody() { return responseBody; }
+    }
 
     @Transactional(readOnly = true)
     public List<ServingTask> getPendingServingCalls(Long boothId) {
@@ -44,8 +70,96 @@ public class ServingTaskService {
         );
     }
 
+    @Transactional(readOnly = true)
+    public ServingFilterOptionsData getFilterOptions(Long boothId, String accessToken) {
+        DjangoAdminMenuListResponse menuListResponse = fetchDjangoMenuList(accessToken);
+        DjangoBoothMypageResponse mypageResponse = fetchDjangoBoothMypage(accessToken);
+
+        List<ServingMenuFilterOption> menus = new ArrayList<>();
+        List<DjangoAdminMenuListResponse.MenuItem> menuItems = menuListResponse != null ? menuListResponse.getData() : null;
+        if (menuItems != null) {
+            for (DjangoAdminMenuListResponse.MenuItem item : menuItems) {
+                if (item == null || item.getId() == null || item.getName() == null) {
+                    continue;
+                }
+                menus.add(new ServingMenuFilterOption(item.getId(), item.getName()));
+            }
+        }
+
+        Integer tableCount = 0;
+        if (mypageResponse != null && mypageResponse.getData() != null && mypageResponse.getData().getTableMaxCnt() != null) {
+            tableCount = mypageResponse.getData().getTableMaxCnt();
+        }
+
+        List<Integer> tables = new ArrayList<>();
+        for (int i = 1; i <= tableCount; i++) {
+            tables.add(i);
+        }
+
+        return new ServingFilterOptionsData(menus, tableCount, tables);
+    }
+
+    private DjangoAdminMenuListResponse fetchDjangoMenuList(String accessToken) {
+        String url = djangoApiBaseUrl + "/api/v3/django/booth/menu-list/";
+        HttpEntity<Void> requestEntity = new HttpEntity<>(buildDjangoAuthHeaders(accessToken));
+
+        try {
+            ResponseEntity<DjangoAdminMenuListResponse> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.GET,
+                    requestEntity,
+                    DjangoAdminMenuListResponse.class
+            );
+            return response.getBody();
+        } catch (HttpClientErrorException e) {
+            throw new DjangoApiException(HttpStatus.valueOf(e.getStatusCode().value()), e.getResponseBodyAsString());
+        }
+    }
+
+    private DjangoBoothMypageResponse fetchDjangoBoothMypage(String accessToken) {
+        String url = djangoApiBaseUrl + "/api/v3/django/booth/mypage/";
+        HttpEntity<Void> requestEntity = new HttpEntity<>(buildDjangoAuthHeaders(accessToken));
+
+        try {
+            ResponseEntity<DjangoBoothMypageResponse> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.GET,
+                    requestEntity,
+                    DjangoBoothMypageResponse.class
+            );
+            return response.getBody();
+        } catch (HttpClientErrorException e) {
+            throw new DjangoApiException(HttpStatus.valueOf(e.getStatusCode().value()), e.getResponseBodyAsString());
+        }
+    }
+
+    private HttpHeaders buildDjangoAuthHeaders(String accessToken) {
+        Map<String, String> csrfData = DjangoApiUtil.getCsrfToken(restTemplate, djangoApiBaseUrl);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        if (csrfData.get("csrfToken") != null) {
+            headers.set("X-CSRFToken", csrfData.get("csrfToken"));
+        }
+
+        StringBuilder cookieBuilder = new StringBuilder();
+        if (csrfData.get("csrfCookie") != null) {
+            cookieBuilder.append(csrfData.get("csrfCookie"));
+        }
+        if (accessToken != null) {
+            if (cookieBuilder.length() > 0) {
+                cookieBuilder.append("; ");
+            }
+            cookieBuilder.append("access_token=").append(accessToken);
+        }
+        if (cookieBuilder.length() > 0) {
+            headers.set(HttpHeaders.COOKIE, cookieBuilder.toString());
+        }
+
+        return headers;
+    }
+
     @Transactional
-    // 🌟 catchedBy 파라미터 삭제됨
     public void catchCall(Long taskId, Long boothId) {
         String lockKey = "lock:serving_task:" + taskId;
         Boolean isAcquired = redisTemplate.opsForValue()
@@ -67,10 +181,8 @@ public class ServingTaskService {
                 throw new IllegalStateException("이미 처리된 요청입니다.");
             }
 
-            // 🌟 actor(catchedBy) 전달 제거
             task.acceptServing();
 
-            // 🌟 publishToDjango 호출 시 파라미터 수정 (null 제외)
             publishToDjango(boothId, "serving", task.getOrderItemId());
             webSocketHandler.broadcastEvent("CATCH_CALL", ServingTaskResponse.from(task));
 
@@ -109,9 +221,6 @@ public class ServingTaskService {
         webSocketHandler.broadcastEvent("CANCEL_CALL", ServingTaskResponse.from(task));
     }
 
-    /**
-     * Django -> Spring : 조리 완료 알림 수신 시 새 serving_task 생성
-     */
     @Transactional
     public void createNewServingTask(Long boothId, Long orderItemId, Integer tableNumber, String menuName, Integer quantity, String key) {
         boolean alreadyExists = servingTaskRepository
@@ -140,23 +249,6 @@ public class ServingTaskService {
 
         webSocketHandler.broadcastEvent("NEW_CALL", ServingTaskResponse.from(newTask));
         log.info("[새 서빙 요청 생성 및 브로드캐스트] boothId={}, orderItemId={}", boothId, orderItemId);
-    }
-
-
-
-    @Transactional(readOnly = true)
-    public ServingFilterOptionsData getFilterOptions(Long boothId) {
-        List<String> menuNames = servingTaskRepository
-                .findDistinctMenuNamesByBoothIdAndStatus(boothId, ServingStatus.SERVE_REQUESTED);
-
-        List<ServingMenuFilterOption> menus = menuNames.stream()
-                .map(menuName -> new ServingMenuFilterOption(menuName, menuName))
-                .toList();
-
-        List<Integer> tables = servingTaskRepository
-                .findDistinctTableNumbersByBoothIdAndStatus(boothId, ServingStatus.SERVE_REQUESTED);
-
-        return new ServingFilterOptionsData(menus, tables);
     }
 
     @Transactional
@@ -211,13 +303,11 @@ public class ServingTaskService {
         return payload;
     }
 
-    // 🌟 catchedBy 파라미터 삭제
     private void publishToDjango(Long boothId, String status, Long orderItemId) {
         try {
             ServingStatusMessageDto messageDto = ServingStatusMessageDto.builder()
                     .orderItemId(orderItemId)
                     .status(status)
-                    // 🌟 OffsetDateTime 적용
                     .pushedAt(OffsetDateTime.now())
                     .build();
 

--- a/spring/src/main/java/com/example/spring/service/serving/ServingTaskService.java
+++ b/spring/src/main/java/com/example/spring/service/serving/ServingTaskService.java
@@ -3,6 +3,8 @@ package com.example.spring.service.serving;
 import com.example.spring.domain.serving.ServingStatus;
 import com.example.spring.domain.serving.ServingTask;
 import com.example.spring.dto.redis.ServingStatusMessageDto;
+import com.example.spring.dto.serving.response.ServingFilterOptionsData;
+import com.example.spring.dto.serving.response.ServingMenuFilterOption;
 import com.example.spring.dto.serving.response.ServingTaskResponse;
 import com.example.spring.repository.serving.ServingTaskRepository;
 import com.example.spring.websocket.ServingWebSocketHandler;
@@ -111,7 +113,7 @@ public class ServingTaskService {
      * Django -> Spring : 조리 완료 알림 수신 시 새 serving_task 생성
      */
     @Transactional
-    public void createNewServingTask(Long boothId, Long orderItemId, Integer tableNumber, String key) {
+    public void createNewServingTask(Long boothId, Long orderItemId, Integer tableNumber, String menuName, Integer quantity, String key) {
         boolean alreadyExists = servingTaskRepository
                 .findFirstByBoothIdAndOrderItemIdAndStatusIn(
                         boothId,
@@ -129,6 +131,8 @@ public class ServingTaskService {
                 .boothId(boothId)
                 .orderItemId(orderItemId)
                 .tableNumber(tableNumber)
+                .menuName(menuName)
+                .quantity(quantity)
                 .key(key)
                 .build();
 
@@ -136,6 +140,23 @@ public class ServingTaskService {
 
         webSocketHandler.broadcastEvent("NEW_CALL", ServingTaskResponse.from(newTask));
         log.info("[새 서빙 요청 생성 및 브로드캐스트] boothId={}, orderItemId={}", boothId, orderItemId);
+    }
+
+
+
+    @Transactional(readOnly = true)
+    public ServingFilterOptionsData getFilterOptions(Long boothId) {
+        List<String> menuNames = servingTaskRepository
+                .findDistinctMenuNamesByBoothIdAndStatus(boothId, ServingStatus.SERVE_REQUESTED);
+
+        List<ServingMenuFilterOption> menus = menuNames.stream()
+                .map(menuName -> new ServingMenuFilterOption(menuName, menuName))
+                .toList();
+
+        List<Integer> tables = servingTaskRepository
+                .findDistinctTableNumbersByBoothIdAndStatus(boothId, ServingStatus.SERVE_REQUESTED);
+
+        return new ServingFilterOptionsData(menus, tables);
     }
 
     @Transactional
@@ -167,13 +188,7 @@ public class ServingTaskService {
                     buildRemoveCallPayload(boothId, reason, deletedCount, null, tableNumber)
             );
         }
-        if ("TABLE_RESET".equals(reason)) {
-            log.info("[테이블 초기화] 서빙태스크 삭제 boothId={}, tableNumber={}, deletedCount={}",
-                    boothId, tableNumber, deletedCount);
-        } else {
-            log.info("[테이블 기준 서빙 요청 삭제] boothId={}, tableNumber={}, reason={}, deletedCount={}",
-                    boothId, tableNumber, reason, deletedCount);
-        }
+        log.info("[테이블 기준 서빙 요청 삭제] boothId={}, tableNumber={}, reason={}, deletedCount={}", boothId, tableNumber, reason, deletedCount);
     }
 
     private Map<String, Object> buildRemoveCallPayload(


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

✨ [Feat] : 서빙 필터링 옵션 조회 API 연동

## 📍 PR Point

- 서빙 직원 화면에서 메뉴 필터와 테이블 번호 필터 옵션을 불러오는 API를 추가했습니다.
- 기존 메뉴 목록 / 테이블 번호 조회 로직을 신규 Spring API 기반으로 변경했습니다.
- `GET /api/v3/spring/serving/filter-options` 응답값을 기반으로 필터 옵션을 구성하도록 반영했습니다.
- 메뉴 필터는 메뉴명 기준, 테이블 필터는 테이블 번호 배열 기준으로 적용되도록 정리했습니다.

## 📢 Notices

- 해당 API는 쿠키 기반 인증을 사용하므로 별도의 Authorization Header는 추가하지 않습니다.
- 기존 서빙 요청 목록 조회 API와 WebSocket 로직은 유지했습니다.
- 필터 옵션 API는 화면 진입 시 필요한 메뉴/테이블 필터 데이터를 불러오는 용도로 사용됩니다.

## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

- #278 