### PR TITLE
✨ [Feature] #348 - 고객용 부스 식별자 UUID 변환

### DIFF
--- a/django/booth/migrations/0006_booth_public_id.py
+++ b/django/booth/migrations/0006_booth_public_id.py
@@ -1,0 +1,30 @@
+import uuid
+from django.db import migrations, models
+
+
+def generate_unique_public_ids(apps, schema_editor):
+    Booth = apps.get_model('booth', 'Booth')
+    for booth in Booth.objects.all():
+        booth.public_id = uuid.uuid4()
+        booth.save(update_fields=['public_id'])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('booth', '0005_alter_booth_options'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='booth',
+            name='public_id',
+            field=models.UUIDField(default=uuid.uuid4, editable=False, null=True),
+        ),
+        migrations.RunPython(generate_unique_public_ids, migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name='booth',
+            name='public_id',
+            field=models.UUIDField(default=uuid.uuid4, editable=False, unique=True),
+        ),
+    ]

--- a/django/booth/models.py
+++ b/django/booth/models.py
@@ -1,3 +1,4 @@
+import uuid
 from django.db import models
 from django.contrib.auth.models import User
 
@@ -11,7 +12,8 @@ from django.core.files.base import ContentFile
 # Create your models here.
 class Booth(models.Model):
     user = models.OneToOneField(User, on_delete=models.CASCADE, primary_key=True, related_name='booth') # user를 booth의 pk로 사용
-    
+    public_id = models.UUIDField(default=uuid.uuid4, unique=True, editable=False)
+
     # 이름
     name = models.CharField(max_length=20)
 
@@ -54,7 +56,7 @@ class Booth(models.Model):
             self.qr_image.delete(save=False)
 
         
-        qr_data = f"https://{settings.CUSTOMER_FRONT_BASE_URL}/?id={self.pk}"  
+        qr_data = f"https://{settings.CUSTOMER_FRONT_BASE_URL}/?id={self.public_id}"
         qr = qrcode.QRCode(version=1, box_size=10, border=5)
         qr.add_data(qr_data)
         qr.make(fit=True)
@@ -62,7 +64,7 @@ class Booth(models.Model):
         img = qr.make_image(fill='black', back_color='white')
         buffer = BytesIO()
         img.save(buffer, format='PNG')
-        file_name = f'booth_{self.pk}_qr.png'
+        file_name = f'booth_{self.public_id}_qr.png'
         self.qr_image.save(file_name, ContentFile(buffer.getvalue()), save=False)
 
     # 최초 생성 시 이미지가 없으면 자동 생성

--- a/django/booth/urls.py
+++ b/django/booth/urls.py
@@ -4,7 +4,7 @@ from .views import *
 urlpatterns = [
     path("mypage/", BoothMyPageAPIView.as_view(), name="mypage"),
     path("mypage/qr-download/", BoothMyPageQRcodeAPIView.as_view(), name="mypage-qrcode"),
-    path("<int:booth_id>/name/", BoothNameAPIView.as_view(), name="name"),
+    path("<uuid:booth_uuid>/name/", BoothNameAPIView.as_view(), name="name"),
     # TODO: 테스트용 - 운영 환경에서는 제거 또는 권한 강화 필요
     path("mypage/reset-table-data/", BoothTableUsageResetAPIView.as_view(), name="reset-table-data"),
 ]

--- a/django/booth/views.py
+++ b/django/booth/views.py
@@ -74,11 +74,11 @@ class BoothNameAPIView(APIView):
     permission_classes = [AllowAny]
     authentication_classes = []
 
-    def get(self,request, booth_id):
+    def get(self, request, booth_uuid):
 
         # 못찾을때
         try:
-            booth = Booth.objects.get(pk = booth_id)
+            booth = Booth.objects.get(public_id=booth_uuid)
         except Booth.DoesNotExist:
             return Response({
                 "message" : "해당 부스를 찾을 수 없습니다."

--- a/django/menu/tests.py
+++ b/django/menu/tests.py
@@ -28,7 +28,7 @@ class UserMenuListAPITest(APITestCase):
         self.menu = Menu.objects.create(booth=self.booth, name='피자', category='MENU', price=20000, stock=5)
         self.setmenu = SetMenu.objects.create(booth=self.booth, name='A세트', price=30000, description='세트 메뉴', image=None)
         self.usage = TableUsage.objects.create(table=self.table, started_at=timezone.now())
-        self.url = f'/api/v3/django/booth/{self.booth.pk}/menu-list/'
+        self.url = f'/api/v3/django/booth/{self.booth.public_id}/menu-list/'
 
     def test_menu_list_without_table_num(self):
         """table_num 없이 메뉴판 조회시 table_info 미포함, 메뉴 데이터만 반환"""

--- a/django/menu/urls.py
+++ b/django/menu/urls.py
@@ -12,5 +12,5 @@ urlpatterns = [
     
     # 전체 메뉴판 조회
     path('menu-list/', BoothMenuListAPIView.as_view(), name='booth-menu-list'),
-    path('<int:booth_id>/menu-list/', UserMenuListAPIView.as_view()),
+    path('<uuid:booth_uuid>/menu-list/', UserMenuListAPIView.as_view()),
 ]

--- a/django/menu/views.py
+++ b/django/menu/views.py
@@ -303,9 +303,9 @@ class UserMenuListAPIView(APIView):
     """
     authentication_classes = []  # JWT 인증 비활성화
     permission_classes = [AllowAny]  # 로그인 없이 접근 가능
-    def get(self, request, booth_id):
+    def get(self, request, booth_uuid):
         table_num = request.GET.get('table_num')
-        booth = get_object_or_404(Booth, pk=booth_id)
+        booth = get_object_or_404(Booth, public_id=booth_uuid)
         table_info = None
         if table_num is not None:
             try:

--- a/django/table/tests.py
+++ b/django/table/tests.py
@@ -585,7 +585,7 @@ class TableEnterTestCase(APITestCase):
         self.client.post(SIGNUP_URL, VALID_SIGNUP_DATA, format='json')
         self.user = User.objects.get(username='testuser')
         self.booth = Booth.objects.get(user=self.user)
-        self.enter_url = f'/api/v3/django/booth/{self.booth.pk}/table/'
+        self.enter_url = f'/api/v3/django/booth/{self.booth.public_id}/table/'
         self.client.cookies.clear()
 
     def test_enter_table_success(self):
@@ -634,7 +634,7 @@ class TableEnterTestCase(APITestCase):
     def test_enter_table_invalid_booth(self):
         """존재하지 않는 부스 입장 시 404"""
         with suppress_request_warnings():
-            response = self.client.post('/api/v3/django/booth/9999/table/', {'table_num': 1}, format='json')
+            response = self.client.post('/api/v3/django/booth/00000000-0000-0000-0000-000000000000/table/', {'table_num': 1}, format='json')
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 

--- a/django/table/urls.py
+++ b/django/table/urls.py
@@ -6,7 +6,7 @@ router = DefaultRouter()
 router.register(r'tables', TableManagementViewSet, basename='tables')
 
 urlpatterns = [
-    path("<int:booth_id>/table/", TableEnterAPIView.as_view(), name="table-enter"),
+    path("<uuid:booth_uuid>/table/", TableEnterAPIView.as_view(), name="table-enter"),
 ]
 
 urlpatterns += router.urls

--- a/django/table/views.py
+++ b/django/table/views.py
@@ -139,7 +139,7 @@ class TableEnterAPIView(views.APIView):
     permission_classes = [AllowAny]
     authentication_classes = []
     
-    def post(self, request, booth_id):
+    def post(self, request, booth_uuid):
         """
         테이블 입장 처리
 
@@ -153,7 +153,7 @@ class TableEnterAPIView(views.APIView):
         """
         # 부스 조회
         try:
-            booth = Booth.objects.get(pk=booth_id)
+            booth = Booth.objects.get(public_id=booth_uuid)
         except Booth.DoesNotExist:
             return Response({
                 "message": "해당 부스를 찾을 수 없습니다."


### PR DESCRIPTION
## 개요

고객에게 노출되는 부스 식별자를 내부 PK(정수)에서 UUID(`public_id`)로 교체합니다.
기존 `?id=4` 형태의 QR 코드 URL은 순차적 정수를 노출해 악의적인 사용자가 타 부스 정보에 임의 접근할 수 있었습니다.

## 변경 사항

### Booth 모델 (`booth/models.py`)
- `public_id = UUIDField(default=uuid4, unique=True, editable=False)` 필드 추가
- QR 코드 생성 시 URL 및 파일명에 `pk` 대신 `public_id` 사용

### 고객용 API URL 변경 (3개 엔드포인트)
| 변경 전 | 변경 후 |
|---|---|
| `GET /api/v3/django/booth/<int:booth_id>/name/` | `GET /api/v3/django/booth/<uuid:booth_uuid>/name/` |
| `POST /api/v3/django/booth/<int:booth_id>/table/` | `POST /api/v3/django/booth/<uuid:booth_uuid>/table/` |
| `GET /api/v3/django/booth/<int:booth_id>/menu-list/` | `GET /api/v3/django/booth/<uuid:booth_uuid>/menu-list/` |

### 마이그레이션 (`booth/migrations/0006_booth_public_id.py`)
- 기존 레코드에 고유 UUID를 할당한 뒤 unique 제약을 적용하는 2단계 마이그레이션

## 변경하지 않은 것
- 내부 PK (`user_id` 기반 OneToOneField) — 유지
- 인증이 필요한 staff/owner API — 내부 식별자 그대로 사용
- `table_usage_id`, `menu_id` 등 기타 고객용 파라미터 — 이번 스코프 외

## 테스트
- `table/tests.py` — `TableEnterTestCase` URL을 `public_id` 기준으로 수정
- `menu/tests.py` — `UserMenuListAPITest` URL을 `public_id` 기준으로 수정
- 전체 151개 테스트 통과 확인

## 체크리스트
- [x] 마이그레이션 적용 확인
- [x] 고객용 3개 엔드포인트 UUID 변환 완료
- [x] QR 코드 URL UUID 반영
- [x] 기존 테스트 수정 및 전체 통과