### PR TITLE
🐛 [Fix : include serving request information in servingtask

### DIFF
--- a/spring/src/main/java/com/example/spring/domain/serving/ServingTask.java
+++ b/spring/src/main/java/com/example/spring/domain/serving/ServingTask.java
@@ -24,6 +24,9 @@ public class ServingTask {
     @Column(name = "table_number")
     private Integer tableNumber;
 
+    @Column(name = "menu_id")
+    private Long menuId;
+
     @Column(name = "menu_name")
     private String menuName;
 
@@ -53,10 +56,11 @@ public class ServingTask {
     private String key;
 
     @Builder
-    public ServingTask(Long boothId, Long orderItemId, Integer tableNumber, String menuName, Integer quantity, String key) {
+    public ServingTask(Long boothId, Long orderItemId, Integer tableNumber, Long menuId, String menuName, Integer quantity, String key) {
         this.boothId = boothId;
         this.orderItemId = orderItemId;
         this.tableNumber = tableNumber;
+        this.menuId = menuId;
         this.menuName = menuName;
         this.quantity = quantity;
         this.status = ServingStatus.SERVE_REQUESTED;

--- a/spring/src/main/java/com/example/spring/dto/redis/OrderCookedMessageDto.java
+++ b/spring/src/main/java/com/example/spring/dto/redis/OrderCookedMessageDto.java
@@ -18,9 +18,13 @@ public class OrderCookedMessageDto {
     @JsonAlias({"table_num", "table_number"})
     private Integer tableNum;
 
+    @JsonProperty("menu_id")
+    private Long menuId;
+
     @JsonProperty("menu_name")
     private String menuName;
 
+    @JsonProperty("quantity")
     private Integer quantity;
 
     private String status; // "cooked"

--- a/spring/src/main/java/com/example/spring/dto/serving/response/ServingTaskResponse.java
+++ b/spring/src/main/java/com/example/spring/dto/serving/response/ServingTaskResponse.java
@@ -13,6 +13,9 @@ public class ServingTaskResponse {
     private Long taskId;
     private Long orderItemId;
     private Integer tableNumber;
+    private Long menuId;
+    private String menuName;
+    private Integer quantity;
     private String status;
     // 🌟 catchedBy 필드 삭제됨
     private LocalDateTime requestedAt;
@@ -22,6 +25,9 @@ public class ServingTaskResponse {
                 .taskId(task.getId())
                 .orderItemId(task.getOrderItemId())
                 .tableNumber(task.getTableNumber())
+                .menuId(task.getMenuId())
+                .menuName(task.getMenuName())
+                .quantity(task.getQuantity())
                 .status(task.getStatus() != null ? task.getStatus().name() : null)
                 // 🌟 catchedBy 매핑 삭제됨
                 .requestedAt(task.getRequestedAt())

--- a/spring/src/main/java/com/example/spring/service/serving/ServingTaskEventListener.java
+++ b/spring/src/main/java/com/example/spring/service/serving/ServingTaskEventListener.java
@@ -39,10 +39,17 @@ public class ServingTaskEventListener {
                     if (dto.getTableNum() == null) {
                         log.warn("[cooked 처리 경고] table_num/table_number 누락. 생성은 진행하지만 reset-by-table 정리에 실패할 수 있습니다. channel={}, message={}", channel, message);
                     }
+                    if (dto.getMenuName() == null || dto.getMenuName().isBlank()) {
+                        log.warn("[cooked 처리 경고] menu_name 누락. 프론트 표시 데이터가 비어있을 수 있습니다. channel={}, message={}", channel, message);
+                    }
+                    if (dto.getQuantity() == null) {
+                        log.warn("[cooked 처리 경고] quantity 누락. 프론트 표시 데이터가 비어있을 수 있습니다. channel={}, message={}", channel, message);
+                    }
                     servingTaskService.createNewServingTask(
                             boothId,
                             dto.getOrderItemId(),
                             dto.getTableNum(),
+                            dto.getMenuId(),
                             dto.getMenuName(),
                             dto.getQuantity(),
                             UUID.randomUUID().toString()

--- a/spring/src/main/java/com/example/spring/service/serving/ServingTaskService.java
+++ b/spring/src/main/java/com/example/spring/service/serving/ServingTaskService.java
@@ -222,7 +222,7 @@ public class ServingTaskService {
     }
 
     @Transactional
-    public void createNewServingTask(Long boothId, Long orderItemId, Integer tableNumber, String menuName, Integer quantity, String key) {
+    public void createNewServingTask(Long boothId, Long orderItemId, Integer tableNumber, Long menuId, String menuName, Integer quantity, String key) {
         boolean alreadyExists = servingTaskRepository
                 .findFirstByBoothIdAndOrderItemIdAndStatusIn(
                         boothId,
@@ -240,6 +240,7 @@ public class ServingTaskService {
                 .boothId(boothId)
                 .orderItemId(orderItemId)
                 .tableNumber(tableNumber)
+                .menuId(menuId)
                 .menuName(menuName)
                 .quantity(quantity)
                 .key(key)


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

🐛 [Fix : include serving request information in servingtask

## 📍 PR Point

- `serving_task`에 `menuId`, `menuName`, `quantity` 필드를 추가했습니다.
- Django cooked Redis 이벤트 payload에서 메뉴 ID, 메뉴명, 수량을 파싱하도록 수정했습니다.
- `GET /serving/servingcall` 응답에 `menuId`, `menuName`, `quantity`가 포함되도록 수정했습니다.
- WebSocket `NEW_CALL` payload에서도 동일한 서빙 요청 정보를 내려주도록 반영했습니다.
- 기존 서빙 요청 생성/삭제/상태 변경 로직은 유지했습니다.

## 📢 Notices

- 기존에 생성된 `serving_task` 데이터는 `menuName`, `quantity`가 `null`일 수 있습니다.
- 새로 조리완료 처리되어 생성되는 서빙 요청부터 메뉴 정보가 정상 반영됩니다.
- DB에 `menu_id`, `menu_name`, `quantity` 컬럼이 필요합니다.

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #
<!-- - ex) #278  -->