### PR TITLE
🐛 [Fix] - TableUsage start_at 수정 시점과 Table 캐러셀 페이지 웹소켓 전송 로직 복구

### DIFF
--- a/django/cart/services.py
+++ b/django/cart/services.py
@@ -760,7 +760,12 @@ def _finalize_payment_core(cart: Cart):
     
     table_usage = TableUsage.objects.select_for_update().get(pk=cart.table_usage_id)
     table_usage.accumulated_amount += order.order_price
-    table_usage.save(update_fields=["accumulated_amount"])
+    update_fields = ["accumulated_amount"]
+    
+    if table_usage.started_at is None:
+        table_usage.started_at = timezone.now()
+        update_fields.append("started_at")
+    table_usage.save(update_fields=update_fields)
 
     return order
 
@@ -782,7 +787,16 @@ def confirm_payment_and_mark_ordered(*, table_usage_id: int) -> Cart:
     cart.save(update_fields=["status", "pending_expires_at"])
 
     final_table_usage_id = cart.table_usage_id
-    booth_id = cart.table_usage.table.booth_id
+    
+    # 주문 확정 시 Table 캐러셀 화면으로 알리기 위해서 웹소켓 전송이 필요합니다!
+    table = cart.table_usage.table
+    booth_id = table.booth_id
+    table_num = table.table_num
+
+    from table.services import OrderBroadcastService
+    OrderBroadcastService.broadcast_order_update(
+        booth_id, table_num, final_table_usage_id
+    )
 
     from .services_ws import broadcast_cart_event
     from order.cache import update_today_revenue


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->
🐛 [Fix] - TableUsage start_at 수정 시점과 Table 캐러셀 페이지 웹소켓 전송 로직 복구

## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #356 
<!-- - ex) #3 -->