### PR TITLE
🐛 [Fix] #283 - JWT 필터 경로 매칭 버그 수정

### DIFF
--- a/spring/src/main/java/com/example/spring/config/SecurityConfig.java
+++ b/spring/src/main/java/com/example/spring/config/SecurityConfig.java
@@ -79,7 +79,6 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        // 허용할 Origin (로컬 개발 환경)
         configuration.setAllowedOrigins(Arrays.asList(
                 "http://localhost:3000",
                 "http://localhost:5173",
@@ -99,7 +98,10 @@ public class SecurityConfig {
                 "http://dev.dorder-api.shop",
                 "https://admin.dorder-api.shop",
                 "https://customer.dorder-api.shop",
-                "https://server.dorder-api.shop"
+                "https://server.dorder-api.shop",
+                "https://d-order-customer.netlify.app",
+                "https://d-order-admin.netlify.app",
+                "https://d-order-server.netlify.app"
         ));
 
         // 허용할 HTTP 메서드

--- a/spring/src/main/java/com/example/spring/config/SecurityConfig.java
+++ b/spring/src/main/java/com/example/spring/config/SecurityConfig.java
@@ -98,10 +98,7 @@ public class SecurityConfig {
                 "http://dev.dorder-api.shop",
                 "https://admin.dorder-api.shop",
                 "https://customer.dorder-api.shop",
-                "https://server.dorder-api.shop",
-                "https://d-order-customer.netlify.app",
-                "https://d-order-admin.netlify.app",
-                "https://d-order-server.netlify.app"
+                "https://server.dorder-api.shop"
         ));
 
         // 허용할 HTTP 메서드

--- a/spring/src/main/java/com/example/spring/security/ServerApiJwtFilter.java
+++ b/spring/src/main/java/com/example/spring/security/ServerApiJwtFilter.java
@@ -79,11 +79,11 @@ public class ServerApiJwtFilter extends OncePerRequestFilter {
     }
 
     private boolean isProtectedPath(String path) {
-        return path.startsWith("/server/") || path.startsWith("/serving/");
+        return path.contains("/server/") || path.contains("/serving/");
     }
 
     private boolean isStaffCallPublicPath(String path) {
-        return "/server/staffcall/request".equals(path)
-                || "/server/staffcall/delete".equals(path);
+        return path.endsWith("/server/staffcall/request")
+                || path.endsWith("/server/staffcall/delete");
     }
 }


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->
수정중 보안 인증이 작동안하는것을 확인해서 수정했습니다. 

ServerApiJwtFilter.java — 경로 매칭 로직 수정

// Before: 실제 경로가 /api/v3/spring/server/... 라서 한 번도 동작 안 함
path.startsWith("/server/")
"/server/staffcall/request".equals(path)

// After
path.contains("/server/")
path.endsWith("/server/staffcall/request")
JWT 필터가 전혀 실행되지 않아 /server/accept, /serving/catchcall 등 인증이 필요한 엔드포인트가 누구나 접근 가능했던 보안 구멍 수정.



## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #283 
<!-- - ex) #3 -->