### PR TITLE
🐛 [Fix] - Cart 앱 로직 수정 및 쿠폰 중복 적용 방지

### DIFF
--- a/django/cart/consumers.py
+++ b/django/cart/consumers.py
@@ -6,7 +6,7 @@ from core.mixins import KoreanAsyncJsonMixin
 from table.models import TableUsage
 from .models import Cart, CartItem
 from .services import *
-from .services_ws import *
+from .services_ws import build_cart_snapshot_data
 
 
 class CustomerCartConsumer(KoreanAsyncJsonMixin, AsyncJsonWebsocketConsumer):

--- a/django/cart/services.py
+++ b/django/cart/services.py
@@ -595,7 +595,7 @@ def enter_payment_info(*, table_usage_id: int):
 
     return cart, payment
 
-@@transaction.atomic
+@transaction.atomic
 def cancel_payment_and_restore_cart(*, table_usage_id: int) -> Cart:
     cart = get_object_or_404(
         Cart.objects.select_for_update(),

--- a/django/cart/services.py
+++ b/django/cart/services.py
@@ -338,29 +338,26 @@ def add_to_cart(*, table_usage_id: int, type: str, quantity: int, menu_id: int =
                     status_code=400,
                 )
 
-            item = CartItem.objects.select_for_update().filter(
-                cart=cart,
-                menu=menu,
-                setmenu=None,
+            existing_item = CartItem.objects.select_for_update().filter(
+                cart=cart, menu=menu, setmenu=None
             ).first()
 
-            new_qty = quantity if item is None else item.quantity + quantity
+            new_qty = quantity if existing_item is None else existing_item.quantity + quantity
             _validate_fee_quantity_policy(booth=booth, quantity=new_qty)
 
-            item, created = CartItem.objects.select_for_update().get_or_create(
-                cart=cart,
-                menu=menu,
-                setmenu=None,
-                defaults={
-                    "quantity": quantity,
-                    "price_at_cart": int(menu.price),
-                },
-            )
-
-            if not created:
-                item.quantity = new_qty
-                item.price_at_cart = int(menu.price)
-                item.save(update_fields=["quantity", "price_at_cart"])
+            if existing_item is None:
+                item = CartItem.objects.create(
+                    cart=cart,
+                    menu=menu,
+                    setmenu=None,
+                    quantity=quantity,
+                    price_at_cart=int(menu.price),
+                )
+            else:
+                existing_item.quantity = new_qty
+                existing_item.price_at_cart = int(menu.price)
+                existing_item.save(update_fields=["quantity", "price_at_cart"])
+                item = existing_item
 
         else:
             if menu.category == Menu.Category.FEE:
@@ -370,23 +367,26 @@ def add_to_cart(*, table_usage_id: int, type: str, quantity: int, menu_id: int =
                     status_code=400,
                 )
 
-            item, created = CartItem.objects.select_for_update().get_or_create(
-                cart=cart,
-                menu=menu,
-                setmenu=None,
-                defaults={
-                    "quantity": quantity,
-                    "price_at_cart": int(menu.price),
-                },
-            )
+            existing_item = CartItem.objects.select_for_update().filter(
+                cart=cart, menu=menu, setmenu=None
+            ).first()
 
-            new_qty = quantity if created else item.quantity + quantity
+            new_qty = quantity if existing_item is None else existing_item.quantity + quantity
             _validate_cart_item_stock(cart=cart, target_menu=menu, new_direct_qty=new_qty)
 
-            if not created:
-                item.quantity = new_qty
-                item.price_at_cart = int(menu.price)
-                item.save(update_fields=["quantity", "price_at_cart"])
+            if existing_item is None:
+                item = CartItem.objects.create(
+                    cart=cart,
+                    menu=menu,
+                    setmenu=None,
+                    quantity=quantity,
+                    price_at_cart=int(menu.price),
+                )
+            else:
+                existing_item.quantity = new_qty
+                existing_item.price_at_cart = int(menu.price)
+                existing_item.save(update_fields=["quantity", "price_at_cart"])
+                item = existing_item
 
     elif type == "setmenu":
         if not set_menu_id:
@@ -401,23 +401,26 @@ def add_to_cart(*, table_usage_id: int, type: str, quantity: int, menu_id: int =
                 status_code=400,
             )
 
-        item, created = CartItem.objects.select_for_update().get_or_create(
-            cart=cart,
-            menu=None,
-            setmenu=setmenu,
-            defaults={
-                "quantity": quantity,
-                "price_at_cart": int(setmenu.price),
-            },
-        )
+        existing_item = CartItem.objects.select_for_update().filter(
+            cart=cart, menu=None, setmenu=setmenu
+        ).first()
 
-        new_qty = quantity if created else item.quantity + quantity
+        new_qty = quantity if existing_item is None else existing_item.quantity + quantity
         _validate_cart_setmenu_stock(cart=cart, target_setmenu=setmenu, new_set_qty=new_qty)
 
-        if not created:
-            item.quantity = new_qty
-            item.price_at_cart = int(setmenu.price)
-            item.save(update_fields=["quantity", "price_at_cart"])
+        if existing_item is None:
+            item = CartItem.objects.create(
+                cart=cart,
+                menu=None,
+                setmenu=setmenu,
+                quantity=quantity,
+                price_at_cart=int(setmenu.price),
+            )
+        else:
+            existing_item.quantity = new_qty
+            existing_item.price_at_cart = int(setmenu.price)
+            existing_item.save(update_fields=["quantity", "price_at_cart"])
+            item = existing_item
 
     else:
         raise CartError("type은 menu, fee 또는 setmenu여야 합니다.", "INVALID_TYPE", status_code=400)
@@ -592,9 +595,12 @@ def enter_payment_info(*, table_usage_id: int):
 
     return cart, payment
 
-@transaction.atomic
+@@transaction.atomic
 def cancel_payment_and_restore_cart(*, table_usage_id: int) -> Cart:
-    cart = get_or_create_cart_by_table_usage(table_usage_id)
+    cart = get_object_or_404(
+        Cart.objects.select_for_update(),
+        table_usage_id=table_usage_id,
+    )
 
     if cart.status != Cart.Status.PENDING:
         raise CartError(
@@ -772,7 +778,7 @@ def _finalize_payment_core(cart: Cart):
                     parent=parent_item,
                     quantity=child_qty,
                     fixed_price=int(child_menu.price),
-                    status="cooking",
+                    status="COOKING",
                 )
 
                 child_menu.stock = F("stock") - child_qty
@@ -794,7 +800,10 @@ def _finalize_payment_core(cart: Cart):
 
 @transaction.atomic
 def confirm_payment_and_mark_ordered(*, table_usage_id: int) -> Cart:
-    cart = get_or_create_cart_by_table_usage(table_usage_id)
+    cart = get_object_or_404(
+        Cart.objects.select_for_update().select_related("table_usage__table__booth"),
+        table_usage_id=table_usage_id,
+    )
 
     if cart.status != Cart.Status.PENDING:
         raise CartError(
@@ -810,8 +819,7 @@ def confirm_payment_and_mark_ordered(*, table_usage_id: int) -> Cart:
     cart.save(update_fields=["status", "pending_expires_at"])
 
     final_table_usage_id = cart.table_usage_id
-    
-    # 주문 확정 시 Table 캐러셀 화면으로 알리기 위해서 웹소켓 전송이 필요합니다!
+
     table = cart.table_usage.table
     booth_id = table.booth_id
     table_num = table.table_num
@@ -830,8 +838,7 @@ def confirm_payment_and_mark_ordered(*, table_usage_id: int) -> Cart:
         today_revenue = update_today_revenue(booth_id, order.order_price)
 
         group_name = f"booth_{booth_id}.order"
-        
-        # 1️⃣ ADMIN_NEW_ORDER 브로드캐스트
+
         async_to_sync(get_channel_layer().group_send)(
             group_name,
             {
@@ -839,8 +846,7 @@ def confirm_payment_and_mark_ordered(*, table_usage_id: int) -> Cart:
                 "data": {"order_id": order.pk},
             }
         )
-        
-        # 2️⃣ total_sales_update 브로드캐스트
+
         async_to_sync(get_channel_layer().group_send)(
             group_name,
             {

--- a/django/cart/views.py
+++ b/django/cart/views.py
@@ -1,8 +1,10 @@
 from django.shortcuts import get_object_or_404
 from rest_framework.views import APIView
 from rest_framework.response import Response
+from django.db import transaction
 
 from table.models import TableUsage
+from coupon.models import CartCouponApply
 from .models import *
 from .serializers import *
 from .services import (
@@ -19,6 +21,7 @@ from .services import (
     _is_fee_booth,
     _can_add_fee_in_this_round,
     build_cart_item_payload,
+    _calc_discount,
 )
 from .services_ws import *
 
@@ -60,11 +63,11 @@ class CartAddAPIView(APIView):
         except CartError as e:
             return error_response(e)
         
-        broadcast_cart_event(
+        transaction.on_commit(lambda: broadcast_cart_event(
             table_usage_id=table_usage_id,
             event_type="CART_ITEM_ADDED",
             message="장바구니에 메뉴가 추가되었습니다.",
-        )
+        ))
 
         return Response(
             {
@@ -113,17 +116,40 @@ class CartDetailAPIView(APIView):
         for it in cart.items.select_related("menu", "setmenu"):
             items.append(build_cart_item_payload(it))   # 여기 수정
 
+        subtotal = cart.cart_price
+        discount_total = 0
         coupon = {
             "applied": False,
             "coupon_id": None,
             "coupon_code": None,
             "discount_type": None,
             "discount_value": None,
-            "discount_amount": None,
+            "discount_amount": 0,
         }
 
-        subtotal = cart.cart_price
-        discount_total = 0
+        applied = (
+            CartCouponApply.objects
+            .filter(cart=cart, round=cart.round)
+            .select_related("coupon_code", "coupon_code__coupon")
+            .first()
+        )
+
+        if applied:
+            cp = applied.coupon_code.coupon
+            discount_total = _calc_discount(
+                subtotal=subtotal,
+                discount_type=cp.discount_type,
+                discount_value=cp.discount_value,
+            )
+            coupon = {
+                "applied": True,
+                "coupon_id": cp.id,
+                "coupon_code": applied.coupon_code.code,
+                "discount_type": cp.discount_type,
+                "discount_value": float(cp.discount_value),
+                "discount_amount": discount_total,
+            }
+
         total = subtotal - discount_total
 
         return Response(
@@ -189,11 +215,11 @@ class CartUpdateQuantityAPIView(APIView):
         except CartError as e:
             return error_response(e)
         
-        broadcast_cart_event(
+        transaction.on_commit(lambda: broadcast_cart_event(
             table_usage_id=table_usage_id,
             event_type="CART_ITEM_UPDATED",
             message="장바구니 수량이 변경되었습니다.",
-        )
+        ))
 
         data = {"cart_price": cart.cart_price}
         if item:
@@ -221,11 +247,11 @@ class CartDeleteItemAPIView(APIView):
         except CartError as e:
             return error_response(e)
         
-        broadcast_cart_event(
+        transaction.on_commit(lambda: broadcast_cart_event(
             table_usage_id=table_usage_id,
             event_type="CART_ITEM_DELETED",
             message="장바구니 항목이 삭제되었습니다.",
-        )
+        ))
 
         return Response({"message": "삭제 성공", "data": {"cart_price": cart.cart_price}}, status=200)
 
@@ -247,11 +273,11 @@ class CartPaymentInfoAPIView(APIView):
         except CartError as e:
             return error_response(e)
         
-        broadcast_cart_event(
+        transaction.on_commit(lambda: broadcast_cart_event(
             table_usage_id=table_usage_id,
             event_type="CART_PAYMENT_PENDING",
             message="결제 확인 화면으로 이동했습니다.",
-        )
+        ))
 
         return Response(
             {

--- a/django/coupon/services.py
+++ b/django/coupon/services.py
@@ -128,9 +128,16 @@ def apply_coupon_code(*, table_usage_id: int, coupon_code_str: str):
     if code.coupon.booth_id != booth_id:
         raise CouponError("해당 부스에서 사용할 수 없는 쿠폰입니다.", "COUPON_BOOTH_MISMATCH", status_code=400)
 
+    # 결제 확정으로 이미 소진된 코드
     if code.used_at is not None:
         raise CouponError("이미 사용된 쿠폰 코드입니다.", "COUPON_CODE_USED", status_code=400)
 
+    # 다른 cart에서 이미 선점 중인 코드 (결제 전이라도 차단)
+    already_applied = CartCouponApply.objects.filter(coupon_code=code).exclude(cart=cart).exists()
+    if already_applied:
+        raise CouponError("이미 다른 테이블에서 사용 중인 쿠폰 코드입니다.", "COUPON_CODE_IN_USE", status_code=409)
+
+    # 현재 cart에 이미 다른 쿠폰이 적용되어 있는 경우
     if CartCouponApply.objects.filter(cart=cart, round=cart.round).exists():
         raise CouponError("이미 쿠폰이 적용되어 있습니다.", "COUPON_ALREADY_APPLIED", status_code=409)
 


### PR DESCRIPTION
## 🔍 What is the PR?

- 재고 검증 순서 수정 (menu/setmenu 추가 시 DB insert 이전에 검증하도록 변경)
- 결제 취소/확정 시 잘못된 Cart 조회 방식 수정 (`get_or_create` → `get_object_or_404`)
- REST 장바구니 조회(`CartDetailAPIView`)에 쿠폰 할인 미반영 버그 수정
- WS 브로드캐스트 타이밍 수정 (`transaction.on_commit`으로 통일)
- 쿠폰 코드 중복 적용 방지 — 다른 테이블에서 선점 중인 코드 409 차단

## 📍 PR Point

- `add_to_cart`에서 `get_or_create` 이후 재고 검증하던 구조를 `filter().first()` 조회 → 검증 → `create` 순서로 변경
- `cancel_payment_and_restore_cart`, `confirm_payment_and_mark_ordered` 두 함수에서 `get_or_create_cart_by_table_usage` 호출 시 내부적으로 pending 만료 자동 복구가 일어나 PENDING 체크가 실패하던 버그 수정
- `CartDetailAPIView`가 WS 스냅샷과 다른 금액을 내려주던 문제 해소 — 쿠폰 조회 로직 동일하게 반영
- `CartCouponApply` 존재 여부로 코드 선점 상태를 판단해 동일 코드의 중복 적용 원천 차단

## 📢 Notices

- `broadcast_cart_event` 호출 위치가 뷰에서 `transaction.on_commit` 안으로 이동함. 동작은 동일하나 WS 이벤트 발송 시점이 DB 커밋 이후로 보장.
- 쿠폰 에러코드 `COUPON_CODE_IN_USE` (409) 신규 추가. 프론트에서 해당 코드 처리 필요.

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

- #363 