### PR TITLE
[fix]: 메뉴 재고 함께 보내기

### DIFF
--- a/django/menu/views.py
+++ b/django/menu/views.py
@@ -336,6 +336,7 @@ class UserMenuListAPIView(APIView):
                 "price": int(fee_menu.price),
                 "description": fee_menu.description or "",
                 "image": fee_menu.image.url if fee_menu.image else None,
+                "stock": fee_menu.stock,
                 "is_soldout": fee_menu.stock == 0
             }]
         # SET
@@ -366,6 +367,7 @@ class UserMenuListAPIView(APIView):
                 "price": int(menu.price),
                 "description": menu.description or "",
                 "image": menu.image.url if menu.image else None,
+                "stock": menu.stock,
                 "is_soldout": menu.stock == 0
             })
         # DRINK
@@ -378,6 +380,7 @@ class UserMenuListAPIView(APIView):
                 "price": int(drink.price),
                 "description": drink.description or "",
                 "image": drink.image.url if drink.image else None,
+                "stock": drink.stock,
                 "is_soldout": drink.stock == 0
             })
         resp = {

--- a/django/menu/views.py
+++ b/django/menu/views.py
@@ -345,7 +345,9 @@ class UserMenuListAPIView(APIView):
         for setmenu in set_menus:
             origin_price = sum([item.menu.price * item.quantity for item in setmenu.items.all()])
             discount_rate = round((origin_price - setmenu.price) / origin_price * 100, 1) if origin_price > 0 else 0.0
-            is_soldout = any(item.menu.stock == 0 for item in setmenu.items.all())
+            items = list(setmenu.items.all())
+            is_soldout = any(item.menu.stock == 0 for item in items)
+            min_stock = min((item.menu.stock // item.quantity for item in items), default=0)
             set_data.append({
                 "id": setmenu.pk,
                 "name": setmenu.name,
@@ -354,6 +356,7 @@ class UserMenuListAPIView(APIView):
                 "discount_rate": discount_rate,
                 "description": setmenu.description or "",
                 "image": setmenu.image.url if setmenu.image else None,
+                "stock": min_stock,
                 "is_soldout": is_soldout
             })
         set_data.sort(key=lambda x: x['price'], reverse=True)


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->
- 기존 사용자메뉴리스트인 UserMenuListAPIView에서 재고 stock 필드를 보내지 않고 있었음
- 세트메뉴는 is_soldout으로 품절여부 구분하기

## 📍 PR Point

<!-- 나 이 부분 찢었다~! -->

## 📢 Notices

 <!-- 공용으로 사용하는(Extension) 부분에 대한 설명 -->

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - 
<!-- - ex) #3 -->