### PR TITLE
[Feat] 366 - Spring staffcall 웹소켓 PING/PONG 하트비트를 구현한다.

### DIFF
--- a/spring/src/main/java/com/example/spring/websocket/CustomerStaffCallWebSocketHandler.java
+++ b/spring/src/main/java/com/example/spring/websocket/CustomerStaffCallWebSocketHandler.java
@@ -16,6 +16,7 @@ import org.springframework.web.socket.handler.TextWebSocketHandler;
 import java.io.IOException;
 import java.security.SecureRandom;
 import java.time.Duration;
+import java.time.OffsetDateTime;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
@@ -59,6 +60,10 @@ public class CustomerStaffCallWebSocketHandler extends TextWebSocketHandler {
     protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
         JsonNode root = objectMapper.readTree(message.getPayload());
         String type = root.path("type").asText("");
+        if ("PING".equalsIgnoreCase(type)) {
+            sendHeartbeatPong(session);
+            return;
+        }
         if (!"SUBSCRIBE".equalsIgnoreCase(type)) {
             return;
         }
@@ -191,6 +196,16 @@ public class CustomerStaffCallWebSocketHandler extends TextWebSocketHandler {
 
     private String getSubscribeToken(Long staffCallId) {
         return redisTemplate.opsForValue().get(REDIS_SUBSCRIBE_TOKEN_KEY_PREFIX + staffCallId);
+    }
+
+    /** Django cart WS와 동일한 JSON 하트비트 응답 (연결 유지·유휴 끊김 완화). */
+    private void sendHeartbeatPong(WebSocketSession session) throws IOException {
+        Map<String, Object> body = new HashMap<>();
+        body.put("type", "PONG");
+        body.put("timestamp", OffsetDateTime.now().toString());
+        body.put("message", "heartbeat");
+        body.put("data", null);
+        session.sendMessage(new TextMessage(objectMapper.writeValueAsString(body)));
     }
 }
 

--- a/spring/src/main/java/com/example/spring/websocket/StaffCallWebSocketHandler.java
+++ b/spring/src/main/java/com/example/spring/websocket/StaffCallWebSocketHandler.java
@@ -15,6 +15,7 @@ import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 
 import java.io.IOException;
+import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -84,6 +85,10 @@ public class StaffCallWebSocketHandler extends TextWebSocketHandler {
         }
         JsonNode root = objectMapper.readTree(message.getPayload());
         String type = root.path("type").asText("");
+        if ("PING".equalsIgnoreCase(type)) {
+            sendHeartbeatPong(session);
+            return;
+        }
         if (!"LIST".equalsIgnoreCase(type)) {
             return;
         }
@@ -127,5 +132,15 @@ public class StaffCallWebSocketHandler extends TextWebSocketHandler {
         } catch (Exception e) {
             log.error("[staffcall ws] broadcast 실패", e);
         }
+    }
+
+    /** Django cart WS와 동일한 JSON 하트비트 응답 (연결 유지·유휴 끊김 완화). */
+    private void sendHeartbeatPong(WebSocketSession session) throws IOException {
+        Map<String, Object> body = new HashMap<>();
+        body.put("type", "PONG");
+        body.put("timestamp", OffsetDateTime.now().toString());
+        body.put("message", "heartbeat");
+        body.put("data", null);
+        session.sendMessage(new TextMessage(objectMapper.writeValueAsString(body)));
     }
 }


### PR DESCRIPTION
## 🔍 What is the PR?

- Spring **`/ws/customer/staffcall`**, **`/ws/server/staffcall`** WebSocket에서 클라이언트가 보내는 JSON **`PING`** 에 대해 **`PONG`** 응답을 추가
- **`PONG` 페이로드 형식**을 Django 장바구니 WS(`CustomerCartConsumer`)와 맞춤: `type`, `timestamp`, `message: heartbeat`, `data: null`
- 프록시·유휴 타임아웃 등으로 끊기기 쉬운 장시간 연결에서 **연결 유지·유휴 끊김 완화**를 목적으로 함

## 📍 PR Point

- `handleTextMessage` 초입에서 **`PING` 우선 처리** 후 기존 `SUBSCRIBE` / `LIST` 로직과 분리
- 직원/커스터머 staffcall WS **양쪽**에 동일한 `sendHeartbeatPong` 패턴 적용

## 📢 Notices

- **프로토콜(WebSocket) 프레임 Ping/Pong이 아니라**, 애플리케이션 JSON 메시지 기반 하트비트임 (Django cart와 동일 스타일)
- **클라이언트**는 주기적으로 `{"type":"PING"}` 전송 + **PONG 미수신 시 재연결** 정책은 별도 구현 필요

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

- #366