### PR TITLE
[Refactor] #370 - 테이블 초기화 reset 시 staffcall 취소 연계 복구

### DIFF
--- a/spring/src/main/java/com/example/spring/service/serving/ServingTaskEventListener.java
+++ b/spring/src/main/java/com/example/spring/service/serving/ServingTaskEventListener.java
@@ -2,6 +2,7 @@ package com.example.spring.service.serving;
 
 import com.example.spring.dto.redis.OrderCookedMessageDto;
 import com.example.spring.event.RedisMessageEvent;
+import com.example.spring.service.staffcall.StaffCallTableResetService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -9,6 +10,7 @@ import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 @Slf4j
@@ -17,6 +19,7 @@ import java.util.UUID;
 public class ServingTaskEventListener {
 
     private final ServingTaskService servingTaskService;
+    private final StaffCallTableResetService staffCallTableResetService;
     private final ObjectMapper objectMapper;
 
     @EventListener
@@ -82,6 +85,13 @@ public class ServingTaskEventListener {
                         return;
                     }
                     servingTaskService.removeTasksByTableNumber(boothId, dto.getTableNum(), "TABLE_RESET");
+                    try {
+                        List<com.example.spring.domain.staffcall.StaffCall> cancelled =
+                                staffCallTableResetService.voidActiveCallsForTable(boothId, dto.getTableNum());
+                        staffCallTableResetService.publishTableResetNotifications(boothId, cancelled);
+                    } catch (Exception e) {
+                        log.error("[reset staffcall 처리 실패] boothId={}, tableNum={}", boothId, dto.getTableNum(), e);
+                    }
                 }
 
             } catch (Exception e) {


### PR DESCRIPTION
## 🔍 What is the PR?
- 테이블 초기화(`django:booth:*:order:reset`) 이벤트 처리 흐름에서 `staff_call` 취소(CANCELLED) 처리가 누락되어 초기화된 테이블의 staffcall이 PENDING으로 남는 문제를 정리
- reset 이벤트 수신 시 서빙 태스크 정리와 함께 `StaffCallTableResetService`를 호출해 해당 테이블의 staffcall을 CANCELLED로 업데이트
- staffcall 취소 후 직원 WS 스냅샷 갱신 및 고객 WS 상태 푸시까지 이어지도록 연계 복구

## 📍 PR Point
- reset 이벤트 처리 파이프라인에서 **서빙 정리 + staffcall 정리**를 한 곳(`ServingTaskEventListener`)에서 함께 수행하도록 연결을 복구해 “테이블 초기화 후에도 active staffcall이 남는” 케이스를 방지

## 📢 Notices
- 테이블 초기화 시 staffcall은 DB에서 delete가 아니라 **status=CANCELLED로 상태 변경**됩니다.
- staffcall 목록 API/WS는 active(PENDING/ACCEPTED)만 노출하므로, CANCELLED 처리되면 `/server/staffcall` 조회에서 해당 항목이 사라지는 게 정상입니다.

## 💭 Related Issues
- #370