### PR TITLE
fix: 테이블 이용료만 담을때 공백 문제

### DIFF
--- a/django/order/consumers.py
+++ b/django/order/consumers.py
@@ -231,11 +231,17 @@ class AdminOrderManagementConsumer(KoreanAsyncJsonMixin, AsyncJsonWebsocketConsu
         """해당 부스의 PAID 상태 주문을 오래된 순으로 조회 (종료된 테이블 제외)"""
         def _query():
             logger.warning(f"🔍 [Order WS] DB 조회 - booth_id={self.booth_id}")
+            from django.db.models import Q
             qs = Order.objects.filter(
                 order_status="PAID",
                 table_usage__table__booth_id=self.booth_id,
-                table_usage__ended_at__isnull=True,  # ← 테이블 사용 중인 것만 (종료된 테이블 제외)
-            ).select_related("table_usage__table").order_by("created_at")
+                table_usage__ended_at__isnull=True,
+                # FEE 외 아이템이 하나라도 있는 주문만 (FEE only 주문 제외)
+                items__parent__isnull=True,
+            ).filter(
+                Q(items__setmenu__isnull=False) |
+                Q(items__menu__category__in=["MENU", "DRINK"])
+            ).distinct().select_related("table_usage__table").order_by("created_at")
             count = qs.count()
             logger.warning(f"🔍 [Order WS] DB 결과: {count}개 주문")
             return list(qs)


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성 -->
아오 원인 드디어 찾았네 
테이블 이용료만 담았을때 빈 배열로 보내버려서 저런거였음 죄송합니다
## 📍 PR Point

<!-- 나 이 부분 찢었다~! -->

## 📢 Notices

 <!-- 공용으로 사용하는(Extension) 부분에 대한 설명 -->

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

 <!-- 작업한 이슈번호를 # 뒤에 붙여주세요.  -->
 - #
<!-- - ex) #3 -->