### PR TITLE
🔧 [Chore] #375 - prod 서버 DB RDS → Docker PostgreSQL 전환

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -45,6 +45,31 @@ services:
       - d-order-network-prod
     restart: unless-stopped
 
+  postgres:
+    image: postgres:15-alpine
+    container_name: d-order-postgres-prod
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_INITDB_ARGS: -U postgres
+      PGDATA: /var/lib/postgresql/data/pgdata
+      SPRING_DB_USER: ${SPRING_DB_USER}
+      SPRING_DB_PASSWORD: ${SPRING_DB_PASSWORD}
+      TZ: Asia/Seoul
+      PGTZ: Asia/Seoul
+    volumes:
+      - postgres_data_prod:/var/lib/postgresql/data
+      - ./db-scripts/init-db.sh:/docker-entrypoint-initdb.d/init-db.sh
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - d-order-network-prod
+    restart: unless-stopped
+
   redis:
     image: redis:7-alpine
     container_name: d-order-redis-prod
@@ -77,7 +102,7 @@ services:
       DB_NAME: ${POSTGRES_DB}
       DB_USER: ${POSTGRES_USER}
       DB_PASSWORD: ${POSTGRES_PASSWORD}
-      DB_HOST: ${DB_HOST}
+      DB_HOST: postgres
       DB_PORT: 5432
       REDIS_HOST: redis
       REDIS_PORT: 6379
@@ -94,6 +119,8 @@ services:
     expose:
       - '8000'
     depends_on:
+      postgres:
+        condition: service_healthy
       redis:
         condition: service_healthy
     volumes:
@@ -125,7 +152,7 @@ services:
       DB_NAME: ${POSTGRES_DB}
       DB_USER: ${POSTGRES_USER}
       DB_PASSWORD: ${POSTGRES_PASSWORD}
-      DB_HOST: ${DB_HOST}
+      DB_HOST: postgres
       DB_PORT: 5432
       REDIS_HOST: redis
       REDIS_PORT: 6379
@@ -142,6 +169,8 @@ services:
     expose:
       - '8000'
     depends_on:
+      postgres:
+        condition: service_healthy
       redis:
         condition: service_healthy
     volumes:
@@ -167,7 +196,7 @@ services:
       POSTGRES_DB: ${POSTGRES_DB}
       SPRING_DB_USER: ${SPRING_DB_USER}
       SPRING_DB_PASSWORD: ${SPRING_DB_PASSWORD}
-      DB_HOST: ${DB_HOST}
+      DB_HOST: postgres
       SECRET_KEY: ${SECRET_KEY}
       DJANGO_API_URL: ${DJANGO_API_URL}
       REDIS_HOST: redis
@@ -176,6 +205,8 @@ services:
     expose:
       - '8080'
     depends_on:
+      postgres:
+        condition: service_healthy
       redis:
         condition: service_healthy
     healthcheck:
@@ -207,7 +238,7 @@ services:
       POSTGRES_DB: ${POSTGRES_DB}
       SPRING_DB_USER: ${SPRING_DB_USER}
       SPRING_DB_PASSWORD: ${SPRING_DB_PASSWORD}
-      DB_HOST: ${DB_HOST}
+      DB_HOST: postgres
       SECRET_KEY: ${SECRET_KEY}
       DJANGO_API_URL: ${DJANGO_API_URL}
       REDIS_HOST: redis
@@ -216,6 +247,8 @@ services:
     expose:
       - '8080'
     depends_on:
+      postgres:
+        condition: service_healthy
       redis:
         condition: service_healthy
     healthcheck:
@@ -238,6 +271,8 @@ services:
     restart: unless-stopped
 
 volumes:
+  postgres_data_prod:
+    driver: local
   redis_data_prod:
     driver: local
   static_volume_prod:


### PR DESCRIPTION
## 🔍 What is the PR?

- RDS 인스턴스 삭제에 따른 prod 서버 DB 전환
- `docker-compose.prod.yml`에 PostgreSQL 컨테이너 서비스 추가
- dev 서버와 동일한 방식으로 DB를 Docker 내부에서 운영

## 📍 PR Point

- `postgres` 서비스 추가 (postgres:15-alpine, dev와 동일)
- django-blue/green, spring-blue/green의 `DB_HOST`를 RDS 엔드포인트에서 `postgres`(컨테이너 서비스명)로 변경
- django/spring `depends_on`에 postgres healthcheck 조건 추가
- `postgres_data_prod` 볼륨 추가

## 📢 Notices

- prod EC2에서 최초 실행 시 `python manage.py migrate` 필요
- `.prod.env`의 `DB_HOST` 항목은 더 이상 사용되지 않음

## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

- #375