### PR TITLE
🐛 [Fix] #378 #379 - prod 로그 볼륨 누락 및 WebSocket JWT 인증 실패 수정

### DIFF
--- a/django/project/settings.py
+++ b/django/project/settings.py
@@ -233,7 +233,7 @@ SIMPLE_JWT = {
     'AUTH_COOKIE_SECURE': not IS_LOCAL,  # local 제외 HTTPS 환경에서 Secure
     'AUTH_COOKIE_HTTP_ONLY': True,
     'AUTH_COOKIE_SAMESITE': 'None' if IS_DEVELOPMENT else 'Lax',  # dev: cross-origin 쿠키 전송 허용
-    'AUTH_COOKIE_DOMAIN': None if IS_LOCAL else '.dorder-api.shop',
+    'AUTH_COOKIE_DOMAIN': None if IS_LOCAL else ('dev.dorder-api.shop' if IS_DEVELOPMENT else '.dorder-api.shop'),
 }
 
 # Logging 설정
@@ -426,12 +426,12 @@ CSRF_COOKIE_NAME = 'csrftoken'              # 쿠키 이름
 CSRF_COOKIE_SECURE = env.bool('CSRF_COOKIE_SECURE', default=not IS_LOCAL)
 CSRF_COOKIE_HTTPONLY = False                # JavaScript에서 접근 가능 (React에서 필요)
 CSRF_COOKIE_SAMESITE = 'Lax'
-CSRF_COOKIE_DOMAIN = None if IS_LOCAL else '.dorder-api.shop'
+CSRF_COOKIE_DOMAIN = None if IS_LOCAL else ('dev.dorder-api.shop' if IS_DEVELOPMENT else '.dorder-api.shop')
 
 SESSION_COOKIE_SECURE = env.bool('SESSION_COOKIE_SECURE', default=IS_PRODUCTION)
 SESSION_COOKIE_HTTPONLY = env.bool('SESSION_COOKIE_HTTPONLY', default=True)
 SESSION_COOKIE_SAMESITE = 'Lax'
-SESSION_COOKIE_DOMAIN = None if IS_LOCAL else '.dorder-api.shop'
+SESSION_COOKIE_DOMAIN = None if IS_LOCAL else ('dev.dorder-api.shop' if IS_DEVELOPMENT else '.dorder-api.shop')
 
 
 # CSRF 설정

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,9 +13,6 @@ services:
       - certbot_certs:/etc/letsencrypt:ro
       - static_volume_prod:/app/static:ro
       - nginx_logs_prod:/var/log/nginx
-    depends_on:
-      - django-blue
-      - spring-blue
     healthcheck:
       test:
         [

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -55,6 +55,8 @@ services:
       SPRING_DB_PASSWORD: ${SPRING_DB_PASSWORD}
       TZ: Asia/Seoul
       PGTZ: Asia/Seoul
+    ports:
+      - '5432:5432'
     volumes:
       - postgres_data_prod:/var/lib/postgresql/data
       - ./db-scripts/init-db.sh:/docker-entrypoint-initdb.d/init-db.sh
@@ -122,6 +124,7 @@ services:
         condition: service_healthy
     volumes:
       - static_volume_prod:/app/static
+      - django_logs_prod:/app/logs
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:8000/health']
       interval: 15s
@@ -172,6 +175,7 @@ services:
         condition: service_healthy
     volumes:
       - static_volume_prod:/app/static
+      - django_logs_prod:/app/logs
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:8000/health']
       interval: 15s
@@ -275,6 +279,8 @@ volumes:
   static_volume_prod:
     driver: local
   nginx_logs_prod:
+    driver: local
+  django_logs_prod:
     driver: local
   certbot_www:
     driver: local


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

- prod Django 컨테이너 로그 파일이 볼륨 마운트 누락으로 재시작 시 유실되던 문제 수정
- dev/prod 쿠키 도메인 공유로 인해 prod WebSocket 연결 시 JWT 서명 검증 실패하던 문제 수정

## 📍 PR Point

- `docker-compose.prod.yml`: `django-blue`, `django-green`에 `django_logs_prod:/app/logs` 볼륨 마운트 추가 및 named volume 선언
- `docker-compose.prod.yml`: postgres `ports: 5432:5432` 추가 (DataGrip SSH 터널 접속용)
- `settings.py`: `AUTH_COOKIE_DOMAIN`, `CSRF_COOKIE_DOMAIN`, `SESSION_COOKIE_DOMAIN`을 `IS_DEVELOPMENT` 환경에서 `dev.dorder-api.shop`으로 분리 → prod 쿠키와 격리

## 📢 Notices

- dev 서버 쿠키 스코프가 `dev.dorder-api.shop`으로 좁아짐 (기존: `.dorder-api.shop` 전체)
- prod 동작에는 영향 없음
- `chore/#375` 머지 이후 함께 반영됨

## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

- #378
- #379