### PR TITLE
🐛 [Fix] #382 - prod Spring ddl-auto를 update에서 validate로 변경

### DIFF
--- a/spring/src/main/resources/application.yml
+++ b/spring/src/main/resources/application.yml
@@ -127,7 +127,8 @@ spring:
       max-lifetime: 1800000
   jpa:
     hibernate:
-      ddl-auto: update
+      # 운영 스키마는 Django migration 이 관리. Hibernate 가 임의로 ALTER 하지 않도록 validate.
+      ddl-auto: validate
     properties:
       hibernate:
         show_sql: false


### PR DESCRIPTION
관련 이슈: #382

## Summary
- prod profile 의 `ddl-auto: update` → `validate`
- Hibernate 가 매 부팅마다 `table_table`, `table_tableusage` 등 Django 소유 테이블에 `ALTER` 를 시도하다 `must be owner of table` WARN 을 누적시키던 문제 해결
- 운영 스키마의 권위 있는 관리자는 Django migration. Hibernate 는 엔티티-스키마 일치 여부만 검증

## 변경 파일
- `spring/src/main/resources/application.yml` (prod profile, 130줄)

## 사전 조건
- prod DB 에 Spring 전용 테이블(`staff_call`, `serving_task`, `spring_test`) 이 존재해야 함
- 이번 인시던트 복구로 운영에서 이미 세 테이블 생성 완료 
- 누락 테이블 재발 방지는 #383 (init-db.sh `GRANT CREATE` 추가) 에서 처리

## Test plan
- [ ] prod 배포 후 Spring 컨테이너 로그에 `must be owner of table` WARN 이 더 이상 안 보임
- [ ] `Started SpringAppApplication ...` 정상 로그 확인
- [ ] StaffCall / ServingTask 관련 엔드포인트 smoke test