### PR TITLE
🔧 [Chore] #383 - prod DB 초기 세팅 안정화 (compose env 가드 + init-db.sh 보강)

### DIFF
--- a/db-scripts/init-db.sh
+++ b/db-scripts/init-db.sh
@@ -15,15 +15,24 @@ until pg_isready -U postgres; do
   sleep 1
 done
 
-# Spring 유저 생성
-psql -U postgres -d postgres <<-EOSQL
-  CREATE USER $SPRING_USER WITH PASSWORD '$SPRING_DB_PASSWORD';
+# Spring 유저 생성 (재실행해도 안전하도록 존재 여부 확인)
+USER_EXISTS=$(psql -U postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='$SPRING_USER'")
+if [ "$USER_EXISTS" = "1" ]; then
+  psql -U postgres -d postgres <<-EOSQL
+    ALTER USER $SPRING_USER WITH PASSWORD '$SPRING_DB_PASSWORD';
 EOSQL
+else
+  psql -U postgres -d postgres <<-EOSQL
+    CREATE USER $SPRING_USER WITH PASSWORD '$SPRING_DB_PASSWORD';
+EOSQL
+fi
 
 # 데이터베이스에 대한 권한 부여
+# CREATE 권한은 Spring 전용 테이블(staff_call, serving_task 등) 생성에 필요.
+# Django 테이블은 owner=postgres라 Spring이 ALTER/DROP 할 수 없어 권한 격리는 유지됨.
 psql -U postgres -d $DB_NAME <<-EOSQL
   GRANT CONNECT ON DATABASE $DB_NAME TO $SPRING_USER;
-  GRANT USAGE ON SCHEMA public TO $SPRING_USER;
+  GRANT USAGE, CREATE ON SCHEMA public TO $SPRING_USER;
   ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO $SPRING_USER;
   ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE ON SEQUENCES TO $SPRING_USER;
 EOSQL

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -45,14 +45,15 @@ services:
   postgres:
     image: postgres:15-alpine
     container_name: d-order-postgres-prod
+    # 필수 env가 비어 있으면 컨테이너를 띄우지 않음 (빈 비밀번호로 유저가 생성되는 사고 방지)
     environment:
-      POSTGRES_DB: ${POSTGRES_DB}
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB:?POSTGRES_DB not set}
+      POSTGRES_USER: ${POSTGRES_USER:?POSTGRES_USER not set}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD not set}
       POSTGRES_INITDB_ARGS: -U postgres
       PGDATA: /var/lib/postgresql/data/pgdata
-      SPRING_DB_USER: ${SPRING_DB_USER}
-      SPRING_DB_PASSWORD: ${SPRING_DB_PASSWORD}
+      SPRING_DB_USER: ${SPRING_DB_USER:?SPRING_DB_USER not set}
+      SPRING_DB_PASSWORD: ${SPRING_DB_PASSWORD:?SPRING_DB_PASSWORD not set}
       TZ: Asia/Seoul
       PGTZ: Asia/Seoul
     ports:
@@ -194,9 +195,9 @@ services:
     command: ["--spring.profiles.active=prod"]
     environment:
       SPRING_PROFILES_ACTIVE: prod
-      POSTGRES_DB: ${POSTGRES_DB}
-      SPRING_DB_USER: ${SPRING_DB_USER}
-      SPRING_DB_PASSWORD: ${SPRING_DB_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB:?POSTGRES_DB not set}
+      SPRING_DB_USER: ${SPRING_DB_USER:?SPRING_DB_USER not set}
+      SPRING_DB_PASSWORD: ${SPRING_DB_PASSWORD:?SPRING_DB_PASSWORD not set}
       DB_HOST: postgres
       SECRET_KEY: ${SECRET_KEY}
       DJANGO_API_URL: ${DJANGO_API_URL}
@@ -236,9 +237,9 @@ services:
     command: ["--spring.profiles.active=prod"]
     environment:
       SPRING_PROFILES_ACTIVE: prod
-      POSTGRES_DB: ${POSTGRES_DB}
-      SPRING_DB_USER: ${SPRING_DB_USER}
-      SPRING_DB_PASSWORD: ${SPRING_DB_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB:?POSTGRES_DB not set}
+      SPRING_DB_USER: ${SPRING_DB_USER:?SPRING_DB_USER not set}
+      SPRING_DB_PASSWORD: ${SPRING_DB_PASSWORD:?SPRING_DB_PASSWORD not set}
       DB_HOST: postgres
       SECRET_KEY: ${SECRET_KEY}
       DJANGO_API_URL: ${DJANGO_API_URL}


### PR DESCRIPTION
관련 이슈: #383

## Summary
- `docker-compose.prod.yml`: postgres / spring 서비스의 DB 인증 관련 env 에 `\${VAR:?msg}` 가드 추가. env 누락 시 컨테이너가 아예 뜨지 않게 해, 빈 자격증명으로 유저가 생성되는 사고 재발 방지
- `db-scripts/init-db.sh`: `CREATE USER` 를 존재 여부 확인 후 분기하도록 idempotent 화. 운영에서 수동 재실행 시 `role already exists` 없이 안전하게 복구 가능
- `db-scripts/init-db.sh`: `GRANT USAGE` → `GRANT USAGE, CREATE`. Spring 전용 테이블(`staff_call`, `serving_task`, `spring_test`)을 Hibernate 가 생성할 수 있게 함. Django 테이블은 owner=postgres 라 여전히 ALTER/DROP 불가 → 권한 격리 유지

## 변경 파일
- `docker-compose.prod.yml` (postgres + spring-blue + spring-green 의 environment 블록)
- `db-scripts/init-db.sh`

## 배경 (이번 인시던트)
#375 (prod RDS → Docker Postgres 전환) 직후 두 가지 문제가 발생:
1. `FATAL: password authentication failed for user "d_order_spring_user"` — 볼륨 잔존으로 `init-db.sh` 가 스킵되고 Spring 유저가 생성되지 않음 → 운영 수동 복구 완료
2. `permission denied for schema public` — `init-db.sh` 가 `USAGE` 만 부여하고 `CREATE` 를 안 줘서 Spring 전용 테이블 3개가 생성되지 못한 채 부팅 → 운영 수동 복구 완료

본 PR 은 두 시나리오 모두 코드로 못박아 다음 환경 셋업부터 자동 적용되게 함.

## Test plan
- [ ] dev 배포 시 정상 부팅 (compose 가드가 dev 에는 영향 없는지 확인)
- [ ] env 한 개 누락한 상태에서 compose up 시 즉시 실패하는지 로컬에서 검증
- [ ] `bash init-db.sh` 를 수동 재실행해도 에러 없이 idempotent 한지 검증
- [ ] 다음 prod 재구축 시 Spring 이 누락 테이블 없이 정상 부팅

## 관련 PR
- #382 (`ddl-auto: validate` 전환) — 본 PR 의 `GRANT CREATE` 가 우선 적용되어야 안전