### PR TITLE
🐛 [Fix] #393 - prod Spring ddl-auto를 validate에서 none으로

### DIFF
--- a/spring/src/main/resources/application.yml
+++ b/spring/src/main/resources/application.yml
@@ -127,8 +127,9 @@ spring:
       max-lifetime: 1800000
   jpa:
     hibernate:
-      # 운영 스키마는 Django migration 이 관리. Hibernate 가 임의로 ALTER 하지 않도록 validate.
-      ddl-auto: validate
+      # 운영 스키마는 Django migration 이 관리. Hibernate 는 검증/변경 모두 수행하지 않음.
+      # validate 는 Spring 엔티티의 FK 컬럼 매핑(_id 접미사 누락) 정리가 끝난 뒤 재도입 예정 (#393).
+      ddl-auto: none
     properties:
       hibernate:
         show_sql: false


### PR DESCRIPTION
관련 이슈: #393

## Summary
- \`application.yml\` prod profile 의 \`ddl-auto: validate\` → \`ddl-auto: none\`
- 누락 컬럼/매핑 버그로 부팅이 차단되는 상황 해소. Hibernate 는 검증/변경 둘 다 안 함

## 변경 파일
- \`spring/src/main/resources/application.yml\` (prod profile, 131줄)

## 배경
#382 로 prod 의 ddl-auto 를 validate 로 켰는데, 이로 인해 누적 schema drift 가 드러남.
- #387 (BigInt 통일), #390 (\`orderitem.key\` 추가) 까지는 코드/DB 정합으로 해결
- 그 다음 \`Schema-validation: missing column [menu] in table [orderitem]\` 노출 — Spring \`OrderItem.java:22-32\` 의 FK 매핑이 \`_id\` 접미사 없이 작성된 버그. Spring 엔티티 정리 PR 이 별도로 필요한 큰 범위 작업

향후 모델 변경 계획 없으므로, validate 의 안전망 없이도 운영 가능. 매핑 정리가 끝나면 다시 validate 로 전환할 예정.

## Test plan
- [ ] dev 배포 — 영향 없음 (dev profile 은 update 그대로)
- [ ] prod 배포 후 임시 \`docker-compose.override.tmp.yml\` 제거 가능. 정상 \`application.yml\` 의 \`none\` 이 적용되어 Spring 부팅 정상

## Follow-up (별 작업)
- Spring 엔티티 FK 매핑 정리 (\`_id\` 접미사 + \`@JoinColumn\`). 영향 받는 엔티티: \`OrderItem\`, \`ServingTask\`, \`BoothTable\`, \`CartEntity\`, \`TableUsageEntity\`
- 매핑 정리 완료 후 prod/dev profile 모두 \`validate\` 로 통일
- \`booth.table_max_cnt\` validators migration 누락 (이번 인시던트 무관, 정리 필요)