### PR TITLE
🐛 [Fix] #396 - prod Spring ddl-auto를 none에서 update로

### DIFF
--- a/spring/src/main/resources/application.yml
+++ b/spring/src/main/resources/application.yml
@@ -127,9 +127,10 @@ spring:
       max-lifetime: 1800000
   jpa:
     hibernate:
-      # 운영 스키마는 Django migration 이 관리. Hibernate 는 검증/변경 모두 수행하지 않음.
+      # 운영 스키마는 Django migration 이 관리. 단 Spring 측 모델 변경 가능성을 위해 update 유지.
       # validate 는 Spring 엔티티의 FK 컬럼 매핑(_id 접미사 누락) 정리가 끝난 뒤 재도입 예정 (#393).
-      ddl-auto: none
+      # 매 부팅 시 권한 부족 ALTER WARN 누적은 감수.
+      ddl-auto: update
     properties:
       hibernate:
         show_sql: false


### PR DESCRIPTION
관련 이슈: #396 (선행: #393)

## Summary
- \`application.yml\` prod profile 의 \`ddl-auto: none\` → \`ddl-auto: update\`
- 향후 Spring 모델 변경 가능성을 위해 \`none\` 보다 한 단계 완화
- 매 부팅 \`must be owner of table\` WARN 누적은 감수
- \`validate\` 재도입은 Spring 엔티티 FK 매핑 정리(별 작업) 완료 후

## 변경 파일
- \`spring/src/main/resources/application.yml\` (prod profile, 132줄)

## 배경
#393 으로 \`validate\` → \`none\` 후퇴했으나, \`none\` 은 모델 변경 시점마다 임시 override 운영 절차를 요구함. 운영 유연성을 위해 \`update\` 가 더 합리적이라는 결정.

## Test plan
- [x] dev 배포 — 영향 없음 (dev profile 은 이미 update)
- [x] prod 배포 후 Spring 컨테이너 정상 부팅 확인 (이미 임시 override 로 동일 동작 중)
- [ ] prod 임시 \`docker-compose.override.tmp.yml\` 제거 가능