### PR TITLE
🐛 [Fix] - 장바구니 WebSocket 안정화 및 3분 만료 제거

### DIFF
--- a/django/cart/consumers.py
+++ b/django/cart/consumers.py
@@ -1,12 +1,16 @@
+import asyncio
+import logging
+
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
 from asgiref.sync import sync_to_async
 from django.utils import timezone
 
 from core.mixins import KoreanAsyncJsonMixin
 from table.models import TableUsage
-from .models import Cart, CartItem
-from .services import *
 from .services_ws import build_cart_snapshot_data
+
+
+logger = logging.getLogger(__name__)
 
 
 class CustomerCartConsumer(KoreanAsyncJsonMixin, AsyncJsonWebsocketConsumer):
@@ -14,80 +18,146 @@ class CustomerCartConsumer(KoreanAsyncJsonMixin, AsyncJsonWebsocketConsumer):
     손님용 실시간 장바구니 WebSocket Consumer
     """
 
+    HEARTBEAT_INTERVAL_SECONDS = 25
+
     async def connect(self):
         self.table_usage_id = self.scope["url_route"]["kwargs"]["table_usage_id"]
+        self.group_name = f"table_usage_{self.table_usage_id}.cart"
+        self.heartbeat_task = None
 
-        is_valid = await self._validate_table_usage()
+        validation = await self._validate_table_usage()
 
-        if not is_valid:
+        if not validation["is_valid"]:
+
+            await self.accept()
+
+            await self.send_json({
+                "type": "ERROR",
+                "timestamp": timezone.localtime().isoformat(),
+                "message": validation["message"],
+                "data": {
+                    "error_code": validation["error_code"],
+                    "table_usage_id": self.table_usage_id,
+                },
+            })
+
             await self.close(code=4004)
             return
 
-        self.group_name = f"table_usage_{self.table_usage_id}.cart"
-
         await self.channel_layer.group_add(
             self.group_name,
-            self.channel_name
+            self.channel_name,
         )
 
         await self.accept()
 
-        print(f"[CartWS] CONNECT: {self.channel_name}")
+        logger.info(f"[CartWS] CONNECT: {self.channel_name}, table_usage_id={self.table_usage_id}")
+
+        await self.send_json({
+            "type": "SUBSCRIBED",
+            "timestamp": timezone.localtime().isoformat(),
+            "message": "장바구니 웹소켓 구독이 완료되었습니다.",
+            "data": {
+                "table_usage_id": int(self.table_usage_id),
+            },
+        })
 
         await self.send_cart_snapshot()
 
-    async def disconnect(self, close_code):
+        self.heartbeat_task = asyncio.create_task(self._heartbeat_loop())
 
-        print(f"[CartWS] DISCONNECT: {self.channel_name}, code={close_code}")
+    async def disconnect(self, close_code):
+        logger.info(
+            f"[CartWS] DISCONNECT: {self.channel_name}, "
+            f"table_usage_id={getattr(self, 'table_usage_id', None)}, code={close_code}"
+        )
+
+        if getattr(self, "heartbeat_task", None):
+            self.heartbeat_task.cancel()
 
         if hasattr(self, "group_name"):
             await self.channel_layer.group_discard(
                 self.group_name,
-                self.channel_name
+                self.channel_name,
             )
 
     async def receive_json(self, content):
-
         message_type = content.get("type")
 
-        # heartbeat ping 처리
         if message_type == "PING":
-
             await self.send_json({
                 "type": "PONG",
                 "timestamp": timezone.localtime().isoformat(),
                 "message": "heartbeat",
                 "data": None,
             })
-
             return
 
-        # 그 외 메시지 차단
+        if message_type == "PONG":
+            return
+
         await self.send_json({
             "type": "ERROR",
             "timestamp": timezone.localtime().isoformat(),
             "message": "메세지 수신을 지원하지 않습니다. REST API를 사용하세요.",
-            "data": None,
+            "data": {
+                "error_code": "UNSUPPORTED_MESSAGE_TYPE",
+                "received_type": message_type,
+            },
         })
 
-    async def _validate_table_usage(self):
+    async def _heartbeat_loop(self):
+        try:
+            while True:
+                await asyncio.sleep(self.HEARTBEAT_INTERVAL_SECONDS)
 
+                await self.send_json({
+                    "type": "PONG",
+                    "timestamp": timezone.localtime().isoformat(),
+                    "message": "heartbeat",
+                    "data": None,
+                })
+
+        except asyncio.CancelledError:
+            return
+
+        except Exception as e:
+            logger.warning(
+                f"[CartWS] heartbeat failed: table_usage_id={self.table_usage_id}, error={e}"
+            )
+
+    async def _validate_table_usage(self):
         def _query():
             try:
-                table_usage = TableUsage.objects.select_related(
-                    "table",
-                    "table__booth"
-                ).get(id=self.table_usage_id)
+                table_usage = (
+                    TableUsage.objects
+                    .select_related("table", "table__booth")
+                    .get(id=self.table_usage_id)
+                )
 
-                return table_usage.ended_at is None
+                if table_usage.ended_at is not None:
+                    return {
+                        "is_valid": False,
+                        "error_code": "TABLE_USAGE_ENDED",
+                        "message": "이미 종료된 테이블 세션입니다.",
+                    }
+
+                return {
+                    "is_valid": True,
+                    "error_code": None,
+                    "message": "OK",
+                }
 
             except TableUsage.DoesNotExist:
-                return False
+                return {
+                    "is_valid": False,
+                    "error_code": "TABLE_USAGE_NOT_FOUND",
+                    "message": "존재하지 않는 테이블 세션입니다.",
+                }
 
         return await sync_to_async(_query)()
 
     async def send_cart_snapshot(self):
-
         payload = await self._build_cart_payload()
 
         await self.send_json({
@@ -97,7 +167,6 @@ class CustomerCartConsumer(KoreanAsyncJsonMixin, AsyncJsonWebsocketConsumer):
         })
 
     async def cart_updated(self, event):
-
         await self.send_json({
             "type": event.get("event_type", "CART_UPDATED"),
             "timestamp": timezone.localtime().isoformat(),

--- a/django/cart/models.py
+++ b/django/cart/models.py
@@ -26,11 +26,11 @@ class Cart(models.Model):
     round = models.IntegerField(default=0)
 
     def is_pending_expired(self) -> bool:
-        return (
-            self.status == self.Status.PENDING
-            and self.pending_expires_at is not None
-            and self.pending_expires_at < timezone.now()
-        )
+        """
+        결제 대기 3분 만료 정책 제거.
+        pending_payment는 자동 만료되지 않는다.
+        """
+        return False
 
     def __str__(self):
         return f"Cart(table_usage={self.table_usage_id}, status={self.status})"

--- a/django/cart/services.py
+++ b/django/cart/services.py
@@ -11,7 +11,6 @@ from menu.models import *
 from order.models import *
 from .models import *
 
-PENDING_TTL_MINUTES = 3
 
 class CartError(Exception):
     def __init__(self, message, error_code="CART_ERROR", detail=None, available_stock=None, status_code=400):
@@ -82,15 +81,6 @@ def _ensure_table_usage_alive(table_usage: TableUsage):
     if table_usage.ended_at is not None:
         raise CartError("이미 종료된 세션입니다.", "TABLE_USAGE_ENDED", status_code=410)
 
-
-def _restore_if_pending_expired(cart: Cart) -> bool:
-    if not cart.is_pending_expired():
-        return False
-
-    cart.status = Cart.Status.ACTIVE
-    cart.pending_expires_at = None
-    cart.save(update_fields=["status", "pending_expires_at"])
-    return True
 
 
 def _sync_item_prices_to_latest(cart: Cart) -> None:
@@ -280,21 +270,6 @@ def get_or_create_cart_by_table_usage(table_usage_id: int) -> Cart:
 
     cart, _ = Cart.objects.select_for_update().get_or_create(table_usage=table_usage)
 
-    restored = _restore_if_pending_expired(cart)
-
-    if restored:
-        final_table_usage_id = cart.table_usage_id
-
-        from .services_ws import broadcast_cart_event
-
-        transaction.on_commit(
-            lambda: broadcast_cart_event(
-                table_usage_id=final_table_usage_id,
-                event_type="CART_PENDING_EXPIRED",
-                message="결제 대기 시간이 만료되어 장바구니가 다시 활성화되었습니다.",
-            )
-        )
-
     return cart
 
 @transaction.atomic
@@ -328,13 +303,6 @@ def add_to_cart(*, table_usage_id: int, type: str, quantity: int, menu_id: int =
                 raise CartError(
                     "이용료 메뉴만 fee 타입으로 담을 수 있습니다.",
                     "INVALID_FEE_MENU",
-                    status_code=400,
-                )
-
-            if not _can_add_fee_in_this_round(cart):
-                raise CartError(
-                    "자리비는 첫 주문에서만 담을 수 있습니다.",
-                    "FEE_ONLY_FIRST_ROUND",
                     status_code=400,
                 )
 
@@ -466,13 +434,6 @@ def update_item_quantity(*, table_usage_id: int, cart_item_id: int, quantity: in
         )
 
         if menu.category == Menu.Category.FEE:
-            if not _can_add_fee_in_this_round(cart):
-                raise CartError(
-                    "자리비는 첫 주문에서만 수정할 수 있습니다.",
-                    "FEE_ONLY_FIRST_ROUND",
-                    status_code=400,
-                )
-
             _validate_fee_quantity_policy(booth=booth, quantity=quantity)
             item.price_at_cart = int(menu.price)
 
@@ -581,7 +542,7 @@ def enter_payment_info(*, table_usage_id: int):
     total = subtotal - discount_total
 
     cart.status = Cart.Status.PENDING
-    cart.pending_expires_at = timezone.now() + timedelta(minutes=PENDING_TTL_MINUTES)
+    cart.pending_expires_at = None
     cart.save(update_fields=["status", "pending_expires_at"])
 
     booth = cart.table_usage.table.booth

--- a/django/cart/services_ws.py
+++ b/django/cart/services_ws.py
@@ -111,7 +111,21 @@ def build_cart_snapshot_data(table_usage_id: int):
 def broadcast_cart_event(table_usage_id: int, event_type: str, message: str):
     channel_layer = get_channel_layer()
     group_name = f"table_usage_{table_usage_id}.cart"
-    payload = build_cart_snapshot_data(table_usage_id)
+
+    try:
+        payload = build_cart_snapshot_data(table_usage_id)
+
+    except Exception as e:
+        logger.warning(
+            f"[Cart WS] broadcast snapshot build failed: "
+            f"table_usage_id={table_usage_id}, event_type={event_type}, error={e}"
+        )
+
+        payload = {
+            "table_usage_id": table_usage_id,
+            "snapshot_available": False,
+            "error": str(e),
+        }
 
     async_to_sync(channel_layer.group_send)(
         group_name,


### PR DESCRIPTION
## 🔍 What is the PR?

- 장바구니 결제 대기 상태의 3분 자동 만료 로직 제거
- 장바구니 WebSocket heartbeat 처리 추가
- 장바구니 WebSocket 연결 실패 처리 개선
- 장시간 대기 시 발생하던 장바구니 WebSocket 오류 완화

## 📍 PR Point

- `pending_payment` 상태가 자동 만료되지 않도록 수정
- 결제 대기 상태는 결제 취소 또는 결제 확정 API를 통해서만 변경되도록 정리함
- 손님용 장바구니 WebSocket에도 ping/pong 처리를 추가해 연결 안정성 높임
- 유효하지 않은 `table_usage_id` 연결 시 에러 원인을 확인할 수 있도록 변경

## 📢 Notices

- `pending_expires_at`은 응답 구조 유지를 위해 필드는 유지하되, 자동 만료 시간 사용 X
- `CART_PENDING_EXPIRED` 이벤트는 사용 X

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

- #409