### PR TITLE
🐛 [Fix] #411 - deploy-all Blue-Green 배포 시 nginx 컨테이너 미교체로 prod.conf 미반영

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -227,10 +227,11 @@ jobs:
                 keepalive 32;
             }
             UPCONF
-              docker compose -f docker-compose.prod.yml exec nginx nginx -s reload
+              docker compose -f docker-compose.prod.yml pull nginx
+              docker compose -f docker-compose.prod.yml up -d --no-deps --wait nginx
 
               # 전환 후 헬스 확인
-              sleep 3
+              sleep 5
               curl -sf http://localhost/health/django || exit 1
               curl -sf http://localhost/health/spring || exit 1
 


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

- `deploy-all` Blue-Green 배포 else 분기에서 `nginx -s reload` 대신 `pull nginx` + `up -d --no-deps --wait nginx` 로 교체
- 새 nginx 이미지에 bake-in된 `prod.conf`가 실제 서버에 반영되지 않던 버그 수정

## 📍 PR Point

**원인**: `nginx -s reload`는 현재 실행 중인 컨테이너 내부의 config를 다시 로드하는 명령이다. `prod.conf`는 이미지에 구워져 있기 때문에 컨테이너를 교체하지 않으면 새 이미지의 `prod.conf`는 절대 적용되지 않는다.

**수정**: 컨테이너 교체 방식으로 변경. `upstream.conf`는 volume mount이므로 컨테이너 재생성 후에도 직전에 작성한 inactive 백엔드 주소가 그대로 반영된다.

```diff
- docker compose -f docker-compose.prod.yml exec nginx nginx -s reload
+ docker compose -f docker-compose.prod.yml pull nginx
+ docker compose -f docker-compose.prod.yml up -d --no-deps --wait nginx
```

## 📢 Notices

- `PROD-NGINX` 단독 배포 스텝은 이미 올바른 방식(`pull` + `up --no-deps`)을 사용하고 있어 변경 없음
- nginx 컨테이너 재시작 중 약 1~3초 간 짧은 재시작이 발생할 수 있음 (`--wait` 플래그로 healthcheck 통과 보장)
- `sleep 3` → `sleep 5` 로 조정 (컨테이너 재시작 시간 여유)

## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

- #411