### PR TITLE
🐛 [Fix] #416 - clear_stale_domain_cookies SimpleCookie 충돌로 인한 fresh csrftoken Domain 누수

### DIFF
--- a/django/authentication/utils.py
+++ b/django/authentication/utils.py
@@ -1,6 +1,8 @@
 """
 JWT 쿠키 유틸리티 함수
 """
+import http.cookies
+
 from django.conf import settings
 
 
@@ -20,10 +22,25 @@ _STALE_COOKIE_NAMES = ('csrftoken', 'sessionid', 'access_token', 'refresh_token'
 
 
 def clear_stale_domain_cookies(response):
-    """옛 도메인 쿠키(부모도메인/서브도메인 변형)를 모두 expire 처리한다."""
+    """옛 도메인 쿠키(부모도메인/서브도메인 변형)를 모두 expire 처리한다.
+
+    Django response.cookies는 SimpleCookie(이름 기준 dict)라 같은 이름으로
+    여러 도메인 변형을 delete_cookie 호출하면 마지막 entry만 살아남고,
+    또한 후속 set_cookie(domain=None) 호출 시 기존 domain 속성이 누수되어
+    새 쿠키에 잘못된 Domain attr이 붙는 문제가 있다.
+    이를 회피하기 위해 각 변형을 고유한 dict 키로 Morsel 객체를 직접 넣는다.
+    Morsel.key는 'csrftoken' 등 원본 이름을 유지하므로 Set-Cookie 출력은 정상.
+    """
+    past = 'Thu, 01-Jan-1970 00:00:00 GMT'
     for domain in _STALE_COOKIE_DOMAINS:
         for name in _STALE_COOKIE_NAMES:
-            response.delete_cookie(name, domain=domain, path='/')
+            morsel = http.cookies.Morsel()
+            morsel.set(name, '', '')
+            morsel['domain'] = domain
+            morsel['expires'] = past
+            morsel['max-age'] = 0
+            morsel['path'] = '/'
+            response.cookies[f'__stale__{name}__{domain}'] = morsel
     return response
 
 


### PR DESCRIPTION
<!-- 🐛 [Fix] -->
## 🔍 What is the PR?

- `clear_stale_domain_cookies()` 헬퍼를 `http.cookies.Morsel` 직접 생성 방식으로 재작성
- 고유한 dict 키(`__stale__{name}__{domain}`)로 Morsel을 `response.cookies`에 삽입하여 SimpleCookie 이름 충돌 회피
- Morsel의 내부 `.key`는 'csrftoken' 등 원본 이름을 유지 → Set-Cookie 헤더 출력은 정상

## 📍 PR Point

### 발견된 버그

PR #415 머지 후 dev 배포 검증 단계(`curl -i https://dev.dorder-api.shop/api/v3/django/auth/csrf-token/`)에서 다음을 확인:

```
set-cookie: csrftoken=...; Domain=.prod.dorder-api.shop; SameSite=None; Secure
```

- **dev 응답이 prod 도메인의 쿠키를 set 시도** → 브라우저 거부 → csrftoken 미설정
- 의도한 24개 expire 헤더 중 4개만 출력 (이름당 1개)

### 두 가지 결함

1. **SimpleCookie 키 충돌**
   - `response.cookies`는 Python `SimpleCookie` (`dict` 서브클래스, **이름 기준 키잉**)
   - `response.delete_cookie('csrftoken', domain=D1)` → `response.delete_cookie('csrftoken', domain=D2)` → ... 호출 시 dict entry가 매번 덮어써짐
   - 24회(6 도메인 × 4 이름) 호출했지만 **각 이름당 마지막 호출만 살아남음**

2. **Domain 누수**
   - 위 1번에서 마지막 살아남은 Morsel의 `domain` 속성이 그대로 응답에 남아있음
   - 이후 Django CSRF 미들웨어가 `response.set_cookie('csrftoken', NEW, domain=None)` 호출
   - Django `set_cookie` 구현:
     ```python
     if domain is not None:
         self.cookies[key]['domain'] = domain
     ```
     `domain=None`이면 **기존 속성을 덮어쓰지 않음** → helper가 남긴 `.prod.dorder-api.shop`이 fresh csrftoken에 누수
   - 결과: `csrftoken=NEW_TOKEN; Domain=.prod.dorder-api.shop; ...` ← 브라우저 거부

### 해결 방식

```python
for domain in _STALE_COOKIE_DOMAINS:
    for name in _STALE_COOKIE_NAMES:
        morsel = http.cookies.Morsel()
        morsel.set(name, '', '')             # Morsel.key = 'csrftoken' 등
        morsel['domain'] = domain
        morsel['expires'] = past
        morsel['max-age'] = 0
        morsel['path'] = '/'
        # 고유한 dict 키로 삽입 → 이름 충돌 회피
        response.cookies[f'__stale__{name}__{domain}'] = morsel
```

- WSGI 핸들러는 `response.cookies.values()`를 순회해 각 Morsel을 별도 Set-Cookie 헤더로 출력
- Morsel 내부 `.key`는 그대로 'csrftoken'이라 헤더에는 정상 이름 출력
- dict 키가 다르므로 후속 `response.set_cookie('csrftoken', ...)`는 새 Morsel을 별개 entry로 추가 → Domain 누수 없음

### 로컬 단위 검증 결과

```
Total Set-Cookie: 25
Fresh csrftoken: csrftoken=FRESH_TOKEN; expires=...; Max-Age=31449600; Path=/; SameSite=None; Secure   ← Domain attr 없음 ✓
Stale csrftoken: 6개 (각 도메인 변형) ✓
Stale sessionid: 6개 ✓
(access_token / refresh_token도 동일)
```

## 📢 Notices

### 배포 후 검증 필수
머지 → dev 재배포 후 다음 명령으로 확인:
```bash
curl -i https://dev.dorder-api.shop/api/v3/django/auth/csrf-token/
```
fresh csrftoken Set-Cookie에 **`Domain=` attr이 없어야** 정상.

### 회귀 영향 없음
- 다른 view/middleware의 `response.set_cookie` 동작은 영향 없음 (별개 dict entry)
- 로그아웃 시 `delete_jwt_cookies`(host-only delete) + `clear_stale_domain_cookies`(stale variants) 공존 정상

## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가? (dev)
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 로컬 단위 검증 완료

## 💭 Related Issues

- #416
- 후속 fix of #414 (PR #415)