### PR TITLE
🐛 [Fix] #420 - 테이블 초기화 시 상세 WebSocket 채널 누락 수정

### DIFF
--- a/django/table/services.py
+++ b/django/table/services.py
@@ -167,6 +167,18 @@ class TableService:
         transaction.on_commit(send_ws)
 
     @staticmethod
+    def _broadcast_detail(booth_pk, table_num, event):
+        """트랜잭션 커밋 후 특정 테이블 상세 WebSocket 그룹에 이벤트를 전송"""
+        def send_ws():
+            channel_layer = get_channel_layer()
+            if channel_layer is None:
+                logger.error('[TableService] channel_layer 없어요')
+                return
+            async_to_sync(channel_layer.group_send)(f'booth_{booth_pk}.tables.{table_num}', event)
+
+        transaction.on_commit(send_ws)
+
+    @staticmethod
     def _broadcast_to_order_group(booth_pk, event):
         """주문 관리 그룹에 이벤트를 전송 (테이블 초기화 알림 등)"""
         def send_ws():
@@ -365,6 +377,13 @@ class TableService:
                 'count': found_count,
             }
         })
+        for table_num in reset_table_nums:
+            TableService._broadcast_detail(booth.pk, table_num, {
+                'type': 'reset_table',
+                'data': {
+                    'table_num': table_num,
+                }
+            })
         # 주문 관리 대시보드에도 알림 (WebSocket 실시간 반영용)
         TableService._broadcast_to_order_group(booth.pk, {
             'type': 'admin_table_reset',

--- a/django/table/ws_handlers.py
+++ b/django/table/ws_handlers.py
@@ -83,6 +83,20 @@ class TableMixin:
 class TableDetailMixin:
     """특정 테이블 상세 웹소켓 이벤트"""
 
+    async def reset_table(self, event):
+        """테이블 초기화 이벤트
+
+        Args:
+            event : reset_table
+                table_num : 초기화된 테이블 번호
+        """
+        await self.send_json({
+            'type': 'reset_table',
+            'timestamp': timezone.now().isoformat(),
+            'message': f'{event["data"]["table_num"]}번 테이블이 초기화되었습니다.',
+            'data': event['data']
+        })
+
     async def order_update(self, event):
         """주문 변경으로 인한 테이블 상세 업데이트
 


### PR DESCRIPTION
## 🔍 What is the PR?

- 테이블 초기화(`reset_tables`) 시 목록 채널(`booth_{id}.tables`)에만 이벤트를 전송하고, 상세 채널(`booth_{id}.tables.{table_num}`)에는 전송하지 않던 버그 수정

## 📍 PR Point

- `TableService._broadcast_detail()` 메서드 추가 — `booth_{booth_pk}.tables.{table_num}` 상세 그룹으로 `transaction.on_commit` 기반 전송
- `reset_tables`에서 초기화된 각 테이블 번호에 대해 `_broadcast_detail` 호출
- `TableDetailMixin`에 `reset_table` 핸들러 추가 — 상세 Consumer가 이벤트를 수신해 클라이언트에 전달

## 📢 Notices

- 상세 채널 이벤트의 `data`는 `{ table_num }` (단일 번호)으로 목록 채널의 `{ table_nums, count }`와 구조가 다름

## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

- #420