### PR TITLE
🐛 [Fix] #423 - 오늘 매출 Redis 캐시 정합성 결함 (커밋 전 변경 / TOCTOU / 미스 경합 / 자정 경계)

### DIFF
--- a/django/booth/services.py
+++ b/django/booth/services.py
@@ -148,15 +148,19 @@ class BoothService:
         from order.models import Order
         Order.objects.filter(table_usage__table__booth=booth).delete()
 
-        from order.cache import invalidate_today_revenue
-        invalidate_today_revenue(booth.pk)
-
         # 4. 모든 TableUsage 삭제
         #    Cart.table_usage가 CASCADE이므로 Cart도 함께 삭제됨
         deleted_count, _ = TableUsage.objects.filter(table__booth=booth).delete()
 
-        # 5. 총매출 0 초기화 WebSocket 전송 (트랜잭션 커밋 후)
+        # 5. 커밋 후: 매출 캐시 무효화 + 총매출 0 WebSocket 전송
         def _send_ws_after_commit():
+            try:
+                from order.cache import invalidate_today_revenue
+                invalidate_today_revenue(booth.pk)
+            except Exception as e:
+                import logging
+                logging.getLogger(__name__).error(f"[부스 초기화] 매출 캐시 무효화 실패: {e}")
+
             try:
                 from channels.layers import get_channel_layer
                 from asgiref.sync import async_to_sync

--- a/django/cart/services.py
+++ b/django/cart/services.py
@@ -795,8 +795,12 @@ def confirm_payment_and_mark_ordered(*, table_usage_id: int) -> Cart:
     from channels.layers import get_channel_layer
     from asgiref.sync import async_to_sync
 
+    order_date = order.created_at.astimezone().date()
+
     def _after_commit():
-        today_revenue = update_today_revenue(booth_id, order.order_price)
+        today_revenue = update_today_revenue(
+            booth_id, int(order.order_price), for_date=order_date
+        )
 
         group_name = f"booth_{booth_id}.order"
 

--- a/django/order/cache.py
+++ b/django/order/cache.py
@@ -5,28 +5,64 @@
 TTL    : 자정까지 (일 경계 자동 만료)
 
 공개 API:
-  get_today_revenue(booth_id)           → 캐시 우선 조회, 미스 시 DB 초기화
-  update_today_revenue(booth_id, delta) → INCRBY (캐시 미스 시 DB 초기화 후 적용)
-  invalidate_today_revenue(booth_id)    → 캐시 삭제 (다음 조회 시 DB 재계산)
+  get_today_revenue(booth_id, for_date=None)
+      → 캐시 우선 조회, 미스 시 DB 집계 후 SET NX EX
+  update_today_revenue(booth_id, delta, for_date=None)
+      → Lua 스크립트로 INCRBY+EXPIRE 원자 처리, 미스 시 DB 베이스라인 + INCRBY
+  invalidate_today_revenue(booth_id, for_date=None)
+      → 캐시 삭제 (다음 조회 시 DB 재계산)
 """
 
 import logging
+from datetime import date as date_cls, datetime, timedelta
+
 from django.utils import timezone
 
 logger = logging.getLogger(__name__)
 
 
 # ──────────────────────────────────────────────
+# Lua: 키가 존재할 때만 INCRBY + EXPIRE
+# 반환: 새 값 (int) 또는 nil
+# ──────────────────────────────────────────────
+_LUA_INCR_IF_EXISTS = """
+if redis.call('EXISTS', KEYS[1]) == 1 then
+  local v = redis.call('INCRBY', KEYS[1], ARGV[1])
+  redis.call('EXPIRE', KEYS[1], ARGV[2])
+  return v
+else
+  return nil
+end
+"""
+
+
+# ──────────────────────────────────────────────
 # 내부 헬퍼
 # ──────────────────────────────────────────────
 
-def _cache_key(booth_id: int) -> str:
-    return f"booth:{booth_id}:today_revenue:{timezone.localdate().isoformat()}"
+def _resolve_date(for_date):
+    """for_date(None|date|datetime) → 로컬 date"""
+    if for_date is None:
+        return timezone.localdate()
+    if isinstance(for_date, datetime):
+        if timezone.is_aware(for_date):
+            return timezone.localtime(for_date).date()
+        return for_date.date()
+    if isinstance(for_date, date_cls):
+        return for_date
+    raise TypeError(f"for_date must be date/datetime/None, got {type(for_date)!r}")
 
 
-def _ttl_until_midnight() -> int:
-    """오늘 자정까지 남은 초 (최소 1초)"""
-    from datetime import timedelta
+def _cache_key(booth_id: int, for_date=None) -> str:
+    return f"booth:{booth_id}:today_revenue:{_resolve_date(for_date).isoformat()}"
+
+
+def _ttl_until_next_midnight(target_date) -> int:
+    """target_date 다음 자정까지 남은 초 (오늘이 아니면 즉시 만료 직전인 1초)"""
+    today = timezone.localdate()
+    if target_date != today:
+        # 과거 날짜 키는 짧게 유지 (정합성 확보 후 자연 만료)
+        return 60
     now = timezone.localtime()
     midnight = (now + timedelta(days=1)).replace(
         hour=0, minute=0, second=0, microsecond=0
@@ -34,93 +70,108 @@ def _ttl_until_midnight() -> int:
     return max(int((midnight - now).total_seconds()), 1)
 
 
-def _query_db(booth_id: int) -> int:
-    """DB에서 오늘(로컬 날짜) PAID/COMPLETED 주문의 order_price 합산"""
+def _query_db(booth_id: int, for_date=None) -> int:
+    """대상 날짜의 PAID/COMPLETED 주문의 order_price 합산"""
     from order.models import Order
     from django.db.models import Sum
 
+    target = _resolve_date(for_date)
     return (
         Order.objects
         .filter(
             order_status__in=["PAID", "COMPLETED"],
             table_usage__table__booth_id=booth_id,
-            created_at__date=timezone.localdate(),
+            created_at__date=target,
         )
         .aggregate(total=Sum("order_price"))["total"]
     ) or 0
-
-
-def _write_cache(booth_id: int, amount: int) -> None:
-    try:
-        from core.redis_client import get_redis_client
-        get_redis_client().setex(_cache_key(booth_id), _ttl_until_midnight(), amount)
-    except Exception as e:
-        logger.warning(f"[Revenue Cache] 쓰기 실패 booth={booth_id}: {e}")
 
 
 # ──────────────────────────────────────────────
 # 공개 API
 # ──────────────────────────────────────────────
 
-def get_today_revenue(booth_id: int) -> int:
+def get_today_revenue(booth_id: int, for_date=None) -> int:
     """
-    오늘 매출 조회 (캐시 우선).
+    오늘(또는 지정 날짜) 매출 조회.
 
     캐시 히트 → 바로 반환
-    캐시 미스 → DB 쿼리 후 캐시 저장 → 반환
-    Redis 장애 → DB 쿼리 결과 직접 반환
+    캐시 미스 → DB 집계 → SET NX EX 베이스라인 → 반환
+    Redis 장애 → DB 결과 직접 반환
     """
+    target = _resolve_date(for_date)
+    key = _cache_key(booth_id, target)
+
     try:
         from core.redis_client import get_redis_client
-        value = get_redis_client().get(_cache_key(booth_id))
+        redis = get_redis_client()
+        value = redis.get(key)
         if value is not None:
             return int(value)
     except Exception as e:
-        logger.warning(f"[Revenue Cache] 조회 실패 booth={booth_id}: {e}")
+        logger.warning(f"[Revenue Cache] 조회 실패 booth={booth_id} date={target}: {e}")
+        redis = None
 
-    amount = _query_db(booth_id)
-    _write_cache(booth_id, amount)
+    amount = _query_db(booth_id, target)
+
+    if redis is not None:
+        try:
+            # 동시 미스 경합에서 한 쪽만 베이스라인을 채택하도록 NX 사용
+            redis.set(key, amount, ex=_ttl_until_next_midnight(target), nx=True)
+        except Exception as e:
+            logger.warning(f"[Revenue Cache] 베이스라인 저장 실패 booth={booth_id} date={target}: {e}")
+
     return amount
 
 
-def update_today_revenue(booth_id: int, delta: int) -> int:
+def update_today_revenue(booth_id: int, delta: int, for_date=None) -> int:
     """
-    오늘 매출 캐시를 delta 만큼 원자적으로 증감.
+    매출 캐시를 delta 만큼 원자적으로 증감.
 
     delta > 0 : 주문 생성 (order_price 만큼 증가)
     delta < 0 : 주문 취소 (refund_amount 만큼 감소)
 
-    캐시 히트 → INCRBY (원자적, TTL 갱신)
-    캐시 미스 → DB 초기화 후 delta 적용
-    Redis 장애 → DB 쿼리 결과 반환
+    1) Lua 스크립트로 "키 존재 시 INCRBY+EXPIRE" 단일 명령 시도
+    2) 키 부재(nil) 시: _query_db로 베이스라인 산출 → SET NX EX → INCRBY delta → EXPIRE
+       (NX 실패 시 다른 워커가 베이스라인을 박은 것이므로 그대로 INCRBY 진행)
+    3) Redis 장애: DB 재계산 결과 반환 (캐시 미반영)
 
-    Returns: 갱신 후 오늘 매출 (int)
+    Returns: 갱신 후 매출 (int)
     """
+    target = _resolve_date(for_date)
+    key = _cache_key(booth_id, target)
+    ttl = _ttl_until_next_midnight(target)
+
     try:
         from core.redis_client import get_redis_client
         redis = get_redis_client()
-        key = _cache_key(booth_id)
 
-        if redis.exists(key):
-            new_value = int(redis.incrby(key, delta))
-            redis.expire(key, _ttl_until_midnight())
-            return new_value
+        result = redis.eval(_LUA_INCR_IF_EXISTS, 1, key, delta, ttl)
+        if result is not None:
+            return int(result)
+
+        # 캐시 부재 → DB 베이스라인 + delta
+        baseline = _query_db(booth_id, target)
+        # NX로 베이스라인 시도 (실패 시 동시 워커가 이미 박음)
+        redis.set(key, baseline, ex=ttl, nx=True)
+        new_value = int(redis.incrby(key, delta))
+        redis.expire(key, ttl)
+        return new_value
     except Exception as e:
-        logger.warning(f"[Revenue Cache] INCRBY 실패 booth={booth_id}: {e}")
-
-    # 캐시 미스 또는 Redis 장애 → DB 초기화 (delta 포함 최신 값 반환)
-    return get_today_revenue(booth_id)
+        logger.warning(f"[Revenue Cache] update 실패 booth={booth_id} date={target}: {e}")
+        return _query_db(booth_id, target)
 
 
-def invalidate_today_revenue(booth_id: int) -> None:
+def invalidate_today_revenue(booth_id: int, for_date=None) -> None:
     """
-    오늘 매출 캐시를 삭제한다.
+    매출 캐시를 삭제한다.
 
     데이터 포맷 등으로 주문이 일괄 삭제된 경우,
     다음 조회 시 DB에서 재계산되도록 캐시를 무효화한다.
     """
+    target = _resolve_date(for_date)
     try:
         from core.redis_client import get_redis_client
-        get_redis_client().delete(_cache_key(booth_id))
+        get_redis_client().delete(_cache_key(booth_id, target))
     except Exception as e:
-        logger.warning(f"[Revenue Cache] 삭제 실패 booth={booth_id}: {e}")
+        logger.warning(f"[Revenue Cache] 삭제 실패 booth={booth_id} date={target}: {e}")

--- a/django/order/services.py
+++ b/django/order/services.py
@@ -278,7 +278,6 @@ class OrderService:
     # 개별 주문 아이템 취소 (부분/전체)
     # ─────────────────────────────────────────────
     @staticmethod
-    @transaction.atomic
     def cancel_order_item(order_item_id: int, cancel_quantity: int, booth_id: int) -> dict:
         """
         개별 주문 아이템 취소.
@@ -291,6 +290,22 @@ class OrderService:
         Order.order_price 차감, TableUsage.accumulated_amount 차감
         WebSocket 브로드캐스트: ADMIN_ORDER_CANCELLED + TOTAL_SALES_UPDATE
         """
+        revenue_holder: dict = {}
+        result = OrderService._cancel_order_item_atomic(
+            order_item_id, cancel_quantity, booth_id, revenue_holder
+        )
+        if "data" in result and "new_total_sales" in result["data"]:
+            # on_commit 콜백이 setdefault로 채워둔 값을 최종 응답에 반영
+            result["data"]["new_total_sales"] = revenue_holder.get(
+                "new_total_sales", result["data"]["new_total_sales"]
+            )
+        return result
+
+    @staticmethod
+    @transaction.atomic
+    def _cancel_order_item_atomic(
+        order_item_id: int, cancel_quantity: int, booth_id: int, revenue_holder: dict
+    ) -> dict:
         # 1) 대상 아이템 조회
         try:
             item = (
@@ -389,90 +404,94 @@ class OrderService:
         table_usage.accumulated_amount -= refund_amount
         table_usage.save(update_fields=["accumulated_amount"])
 
-        # 11) 오늘 매출 캐시 감소 (DB 쿼리 대체)
-        from order.cache import update_today_revenue
-        new_total_sales = update_today_revenue(booth_id, -refund_amount)
-
         new_item_total_price = item.fixed_price * remaining_quantity
 
-        logger.info(
-            f"[OrderItem 취소] item_id={order_item_id} "
-            f"qty={old_quantity}→{remaining_quantity} "
-            f"환불={refund_amount:,} 새매출={new_total_sales:,}"
+        # 11) 커밋 후 캐시 갱신 + WS 브로드캐스트 + Redis 발행
+        #     트랜잭션 롤백 시 Redis가 함께 어긋나는 것을 막기 위해 on_commit 사용
+        order_date = order.created_at.astimezone().date()
+        order_pk = order.pk
+        table_usage_id = order.table_usage_id
+        table_num = order.table_usage.table.table_num
+        menu_name = (
+            item.setmenu.name if item.setmenu_id
+            else (item.menu.name if item.menu_id else "알 수 없음")
         )
 
-        # 12) WebSocket 브로드캐스트
-        try:
-            from channels.layers import get_channel_layer
-            from asgiref.sync import async_to_sync
+        def _after_commit():
+            from order.cache import update_today_revenue
+            new_total_sales = update_today_revenue(
+                booth_id, -refund_amount, for_date=order_date
+            )
+            revenue_holder["new_total_sales"] = new_total_sales
 
-            group_name = f"booth_{booth_id}.order"
-            channel_layer = get_channel_layer()
-
-            # ADMIN_ORDER_CANCELLED
-            async_to_sync(channel_layer.group_send)(
-                group_name,
-                {
-                    "type": "admin_order_cancelled",
-                    "data": {
-                        "order_id": order.pk,
-                        "item_id": order_item_id,
-                        "refund_amount": refund_amount,
-                        "remaining_quantity": remaining_quantity,
-                        "new_total_sales": new_total_sales,
-                    },
-                }
+            logger.info(
+                f"[OrderItem 취소] item_id={order_item_id} "
+                f"qty={old_quantity}→{remaining_quantity} "
+                f"환불={refund_amount:,} 새매출={new_total_sales:,}"
             )
 
-            # 오늘 매출 갱신 이벤트 (계산된 값 포함)
-            async_to_sync(channel_layer.group_send)(
-                group_name,
-                {"type": "total_sales_update", "data": {"today_revenue": new_total_sales}}
-            )
-        except Exception as e:
-            logger.error(f"[OrderItem 취소] WebSocket 전송 실패: {e}")
+            try:
+                from channels.layers import get_channel_layer
+                from asgiref.sync import async_to_sync
 
-        # 13) Redis 발행 → 스프링부트 (손님 환불 알림)
-        try:
-            import uuid
-            from core.redis_client import publish
+                group_name = f"booth_{booth_id}.order"
+                channel_layer = get_channel_layer()
 
-            menu_name = (
-                item.setmenu.name if item.setmenu_id
-                else (item.menu.name if item.menu_id else "알 수 없음")
-            )
-            now_str = timezone.localtime().isoformat()
+                async_to_sync(channel_layer.group_send)(
+                    group_name,
+                    {
+                        "type": "admin_order_cancelled",
+                        "data": {
+                            "order_id": order_pk,
+                            "item_id": order_item_id,
+                            "refund_amount": refund_amount,
+                            "remaining_quantity": remaining_quantity,
+                            "new_total_sales": new_total_sales,
+                        },
+                    }
+                )
+                async_to_sync(channel_layer.group_send)(
+                    group_name,
+                    {"type": "total_sales_update", "data": {"today_revenue": new_total_sales}}
+                )
+            except Exception as e:
+                logger.error(f"[OrderItem 취소] WebSocket 전송 실패: {e}")
 
-            publish(
-                f"booth:{booth_id}:order:refund",
-                {
-                    "event_id": str(uuid.uuid4()),
-                    "event_type": "order.item_refund",
-                    "occurred_at": now_str,
-                    "data": {
-                        "table_usage_id": order.table_usage_id,
-                        "order_id": order.pk,
-                        "order_item_id": order_item_id,
-                        "menu_name": menu_name,
-                        "cancel_quantity": cancel_quantity,
-                        "refund_price": refund_amount,
-                        "is_full_cancel": remaining_quantity == 0,
-                        "pushed_at": now_str,
-                    },
-                }
-            )
-        except Exception as e:
-            logger.error(f"[OrderItem 취소] Redis 환불 알림 발행 실패: {e}")
+            try:
+                import uuid
+                from core.redis_client import publish
 
-        # 14) 테이블 WebSocket 브로드캐스트
-        try:
-            from table.services import OrderBroadcastService
-            table_num = order.table_usage.table.table_num
-            OrderBroadcastService.broadcast_order_update(
-                booth_id, table_num, order.table_usage_id
-            )
-        except Exception as e:
-            logger.error(f"[OrderItem 취소] 테이블 WS 브로드캐스트 실패: {e}")
+                now_str = timezone.localtime().isoformat()
+                publish(
+                    f"booth:{booth_id}:order:refund",
+                    {
+                        "event_id": str(uuid.uuid4()),
+                        "event_type": "order.item_refund",
+                        "occurred_at": now_str,
+                        "data": {
+                            "table_usage_id": table_usage_id,
+                            "order_id": order_pk,
+                            "order_item_id": order_item_id,
+                            "menu_name": menu_name,
+                            "cancel_quantity": cancel_quantity,
+                            "refund_price": refund_amount,
+                            "is_full_cancel": remaining_quantity == 0,
+                            "pushed_at": now_str,
+                        },
+                    }
+                )
+            except Exception as e:
+                logger.error(f"[OrderItem 취소] Redis 환불 알림 발행 실패: {e}")
+
+            try:
+                from table.services import OrderBroadcastService
+                OrderBroadcastService.broadcast_order_update(
+                    booth_id, table_num, table_usage_id
+                )
+            except Exception as e:
+                logger.error(f"[OrderItem 취소] 테이블 WS 브로드캐스트 실패: {e}")
+
+        transaction.on_commit(_after_commit)
 
         return {
             "success": True,
@@ -482,7 +501,7 @@ class OrderService:
                 "remaining_quantity": remaining_quantity,
                 "refund_amount": refund_amount,
                 "new_item_total_price": new_item_total_price,
-                "new_total_sales": new_total_sales,
+                "new_total_sales": 0,  # 래퍼가 on_commit 후 채움
             },
         }
 
@@ -763,63 +782,68 @@ class OrderService:
             f"price={order.order_price}, discount={order.total_discount}"
         )
 
-        # ⑨ WebSocket 브로드캐스트
+        # ⑨ 커밋 후: 캐시 갱신 + WebSocket 브로드캐스트 + 테이블 브로드캐스트
         booth_id = table_usage.table.booth_id
-        try:
+        order_price_int = int(order.order_price)
+        order_pk = order.pk
+        original_price_int = int(order.original_price) if order.original_price else 0
+        total_discount_int = int(order.total_discount) if order.total_discount else 0
+        order_status_snapshot = order.order_status
+        order_date = order.created_at.astimezone().date()
+        table_num = table_usage.table.table_num
+
+        def _send_ws_events_after_commit():
             from channels.layers import get_channel_layer
             from asgiref.sync import async_to_sync
             from order.cache import update_today_revenue
 
-            # order.order_price를 int로 변환 (Decimal → int)
-            order_price_int = int(order.order_price)
-            today_revenue = update_today_revenue(booth_id, order_price_int)
-            group_name = f"booth_{booth_id}.order"
-            channel_layer = get_channel_layer()
+            try:
+                today_revenue = update_today_revenue(
+                    booth_id, order_price_int, for_date=order_date
+                )
+            except Exception as cache_err:
+                logger.error(f"[Order] 매출 캐시 갱신 실패: {cache_err}")
+                today_revenue = None
 
-            # 트랜잭션 커밋 이후 전송해야 consumer 조회 시 최신 데이터가 보장됨
-            def _send_ws_events_after_commit():
-                try:
-                    async_to_sync(channel_layer.group_send)(
-                        group_name,
-                        {
-                            "type": "admin_new_order",
-                            "data": {
-                                "order_id": order.pk,
-                                "cart_id": cart_id,
-                                "table_usage_id": table_usage_id,
-                                "order_price": order_price_int,
-                                "original_price": int(order.original_price) if order.original_price else 0,
-                                "total_discount": int(order.total_discount) if order.total_discount else 0,
-                                "order_status": order.order_status,
-                            }
+            try:
+                group_name = f"booth_{booth_id}.order"
+                channel_layer = get_channel_layer()
+                async_to_sync(channel_layer.group_send)(
+                    group_name,
+                    {
+                        "type": "admin_new_order",
+                        "data": {
+                            "order_id": order_pk,
+                            "cart_id": cart_id,
+                            "table_usage_id": table_usage_id,
+                            "order_price": order_price_int,
+                            "original_price": original_price_int,
+                            "total_discount": total_discount_int,
+                            "order_status": order_status_snapshot,
                         }
-                    )
-                    # 오늘 매출 갱신 이벤트 (계산된 값 포함 → Consumer DB 쿼리 불필요)
+                    }
+                )
+                if today_revenue is not None:
                     async_to_sync(channel_layer.group_send)(
                         group_name,
                         {"type": "total_sales_update", "data": {"today_revenue": today_revenue}}
                     )
-                    # 메뉴 집계 갱신
-                    async_to_sync(channel_layer.group_send)(
-                        group_name,
-                        {"type": "admin_menu_aggregation", "data": {}}
-                    )
-                except Exception as ws_err:
-                    logger.error(f"[Order] WebSocket 전송 실패 (주문은 정상 생성됨): {ws_err}")
+                async_to_sync(channel_layer.group_send)(
+                    group_name,
+                    {"type": "admin_menu_aggregation", "data": {}}
+                )
+            except Exception as ws_err:
+                logger.error(f"[Order] WebSocket 전송 실패 (주문은 정상 생성됨): {ws_err}")
 
-            transaction.on_commit(_send_ws_events_after_commit)
-        except Exception as ws_err:
-            logger.error(f"[Order] WebSocket 준비 실패 (주문은 정상 생성됨): {ws_err}")
+            try:
+                from table.services import OrderBroadcastService
+                OrderBroadcastService.broadcast_order_update(
+                    booth_id, table_num, table_usage_id
+                )
+            except Exception as e:
+                logger.error(f"[Order] 테이블 WS 브로드캐스트 실패 (주문은 정상 생성됨): {e}")
 
-        # ⑩ 테이블 WebSocket 브로드캐스트
-        try:
-            from table.services import OrderBroadcastService
-            table_num = table_usage.table.table_num
-            OrderBroadcastService.broadcast_order_update(
-                booth_id, table_num, table_usage_id
-            )
-        except Exception as e:
-            logger.error(f"[Order] 테이블 WS 브로드캐스트 실패 (주문은 정상 생성됨): {e}")
+        transaction.on_commit(_send_ws_events_after_commit)
 
         # ✅ 주문 생성 성공 반환
         return {"result": "success", "order_id": order.pk}

--- a/django/order/test_cache.py
+++ b/django/order/test_cache.py
@@ -1,0 +1,144 @@
+"""
+오늘 매출 캐시(order/cache.py) 정합성 테스트.
+
+DB는 _query_db 호출 모킹으로 우회. Redis는 실제 컨테이너 사용.
+"""
+
+from datetime import timedelta
+from unittest.mock import patch, MagicMock
+
+import pytest
+from django.utils import timezone
+
+from order import cache as revenue_cache
+
+
+BOOTH_ID = 999_001
+
+
+@pytest.fixture(autouse=True)
+def clean_cache():
+    """각 테스트 전후로 테스트용 부스의 매출 캐시 키를 비운다."""
+    from core.redis_client import get_redis_client
+    try:
+        redis = get_redis_client()
+        for key in redis.scan_iter(f"booth:{BOOTH_ID}:today_revenue:*"):
+            redis.delete(key)
+    except Exception:
+        pass
+    yield
+    try:
+        redis = get_redis_client()
+        for key in redis.scan_iter(f"booth:{BOOTH_ID}:today_revenue:*"):
+            redis.delete(key)
+    except Exception:
+        pass
+
+
+# ──────────────────────────────────────────────
+# 1) 트랜잭션 롤백 시 캐시 불변
+# ──────────────────────────────────────────────
+
+def test_revenue_cache_unaffected_on_rollback():
+    """호출부가 on_commit 콜백 안에서 update_today_revenue를 호출하도록
+    이동된 결과, atomic 블록이 롤백되면 캐시가 변하지 않는지를 검증.
+
+    실제 DB 트랜잭션 대신 Django의 transaction.on_commit 의미를 mock으로
+    재현 — 롤백 시 on_commit 콜백을 호출하지 않는 동작을 시뮬레이션.
+    """
+    # 사전 베이스라인: 캐시에 10000 박아둠
+    with patch.object(revenue_cache, "_query_db", return_value=10000):
+        revenue_cache.update_today_revenue(BOOTH_ID, 0)
+    assert revenue_cache.get_today_revenue(BOOTH_ID) == 10000
+
+    # transaction.on_commit이 호출되었지만 atomic 블록이 롤백된 상황 모사
+    pending = []
+    def fake_on_commit(cb):
+        pending.append(cb)
+
+    with patch("django.db.transaction.on_commit", side_effect=fake_on_commit):
+        from django.db import transaction as tx
+        def _bump():
+            revenue_cache.update_today_revenue(BOOTH_ID, 5000)
+        tx.on_commit(_bump)
+        # ↑ 실제 운영 코드의 on_commit 등록 흐름. 롤백 시 pending 콜백은 폐기됨.
+
+    # 롤백 시뮬레이션: pending 콜백을 호출하지 않고 폐기
+    assert len(pending) == 1
+    pending.clear()
+
+    # 캐시는 베이스라인 그대로
+    assert revenue_cache.get_today_revenue(BOOTH_ID) == 10000
+
+    # 커밋 시뮬레이션: 콜백 실행 시 캐시가 변경됨을 함께 확인 (positive control)
+    pending2 = []
+    with patch("django.db.transaction.on_commit", side_effect=lambda cb: pending2.append(cb)):
+        from django.db import transaction as tx
+        tx.on_commit(lambda: revenue_cache.update_today_revenue(BOOTH_ID, 5000))
+    for cb in pending2:
+        cb()
+    assert revenue_cache.get_today_revenue(BOOTH_ID) == 15000
+
+
+# ──────────────────────────────────────────────
+# 2) 동시 캐시 미스에서 합산 보존 (SET NX 베이스라인)
+# ──────────────────────────────────────────────
+
+def test_concurrent_miss_no_lost_update():
+    """두 트랜잭션이 동시에 캐시 미스를 만났을 때, 먼저 베이스라인을 박은
+    쪽이 채택되고 나중 쪽은 INCRBY로 합산되어야 한다 (SET NX 효과)."""
+    key = revenue_cache._cache_key(BOOTH_ID)
+
+    calls = {"n": 0}
+    def fake_query_db(booth_id, for_date=None):
+        calls["n"] += 1
+        return 1000 if calls["n"] == 1 else 3000
+
+    with patch.object(revenue_cache, "_query_db", side_effect=fake_query_db):
+        v1 = revenue_cache.update_today_revenue(BOOTH_ID, 1000)
+        v2 = revenue_cache.update_today_revenue(BOOTH_ID, 3000)
+
+    # 첫 호출: 베이스라인 1000 + delta 1000 = 2000
+    assert v1 == 2000
+    # 두 번째: 캐시 히트 (Lua INCRBY) → 2000 + 3000 = 5000
+    assert v2 == 5000
+
+    from core.redis_client import get_redis_client
+    assert int(get_redis_client().get(key)) == 5000
+
+
+# ──────────────────────────────────────────────
+# 3) 자정 경계: for_date 인자로 어제 키를 지정
+# ──────────────────────────────────────────────
+
+def test_yesterday_order_uses_yesterday_key():
+    """for_date를 명시하면 어제 키에 INCRBY되어야 하고 오늘 키는 건드리지 않아야 한다."""
+    today = timezone.localdate()
+    yesterday = today - timedelta(days=1)
+
+    today_key = revenue_cache._cache_key(BOOTH_ID, today)
+    yesterday_key = revenue_cache._cache_key(BOOTH_ID, yesterday)
+
+    with patch.object(revenue_cache, "_query_db", return_value=0):
+        revenue_cache.update_today_revenue(BOOTH_ID, 7000, for_date=yesterday)
+
+    from core.redis_client import get_redis_client
+    redis = get_redis_client()
+    assert redis.get(today_key) is None
+    assert int(redis.get(yesterday_key)) == 7000
+
+
+# ──────────────────────────────────────────────
+# 4) TOCTOU: Lua 스크립트가 키 부재 시 nil → 폴백이 베이스라인 + INCRBY
+# ──────────────────────────────────────────────
+
+def test_toctou_lua_returns_nil_falls_back_to_baseline():
+    """Lua 스크립트가 nil을 반환하면 _query_db로 베이스라인을 박고 INCRBY로 delta를 더한다.
+    기존 exists+incrby 분리 구조의 TTL 만료 race를 단일 명령으로 차단한 것을 검증."""
+    with patch.object(revenue_cache, "_query_db", return_value=4000):
+        new_value = revenue_cache.update_today_revenue(BOOTH_ID, 1500)
+
+    assert new_value == 5500
+
+    from core.redis_client import get_redis_client
+    assert int(get_redis_client().get(revenue_cache._cache_key(BOOTH_ID))) == 5500


### PR DESCRIPTION
<!-- 🐛 [Fix] -->
## 🔍 What is the PR?

- `order/cache.py`의 매출 캐시 정합성 결함 4건 + 부수 UX 결함 1건을 통합 수정 (issue #423)
- Lua EVAL 기반 atomic INCRBY+EXPIRE로 `exists`–`incrby` TOCTOU 차단
- `SET NX EX` 베이스라인으로 동시 캐시 미스 시 업데이트 유실 방지
- 모든 캐시 API에 `for_date` 인자 추가 — 자정 경계에서 어제 주문 처리가 어제 키에 정확히 반영
- `order/services.py:394`(취소) / `:775`(주문 생성)의 캐시·WS·Redis 발행을 `transaction.on_commit` 콜백으로 이동 → 롤백 시 캐시 드리프트 차단, `cart/services.py`와 패턴 통일
- `booth/services.py`의 `invalidate_today_revenue`도 on_commit 안으로 이동
- `order/test_cache.py` 신설: 롤백 불변 / 동시 미스 합산 보존 / 자정 경계 / TOCTOU 4종 단위 테스트

## 📍 PR Point

- **on_commit 패턴 통일**: `cancel_order_item`은 응답 dict에 `new_total_sales`를 반환해야 해서 `_cancel_order_item_atomic` 내부 함수 + 래퍼 함수로 분리. 래퍼가 `revenue_holder`를 전달하고, on_commit 콜백이 채운 값을 응답에 후채움.
- **Lua 스크립트**: 키가 있을 때만 INCRBY+EXPIRE를 단일 EVAL로 처리. nil 반환 시 폴백 경로(`_query_db` → `SET NX EX` → `INCRBY delta`)로 베이스라인 + 합산.
- **`for_date` 시그니처 확장**: `_cache_key`, `_query_db`, `get_today_revenue`, `update_today_revenue`, `invalidate_today_revenue` 모두 옵셔널 인자. 호출부는 `order.created_at.astimezone().date()` 전달.

## 📢 Notices

- `OrderItemCancelResponseSerializer.new_total_sales`는 그대로 유지. 래퍼 함수가 on_commit 후 값을 응답에 반영하므로 외부 API 계약 변화 없음.
- 외부 atomic이 감싸는 호출 경로는 현재 없음 (DRF `ATOMIC_REQUESTS` 미설정). 향후 추가 시에는 on_commit 발화 시점이 외부 atomic 커밋 후로 미뤄지므로 응답 dict 채움 흐름을 다시 점검 필요.

## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가? (base: `dev`)
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] `pytest order/ -v` 전체 14건 통과 확인

## 💭 Related Issues

- #423