### PR TITLE
🐛 [Fix] : scope ws broadcasts by boothID

### DIFF
--- a/spring/src/main/java/com/example/spring/config/WebSocketConfig.java
+++ b/spring/src/main/java/com/example/spring/config/WebSocketConfig.java
@@ -33,7 +33,7 @@ public class WebSocketConfig implements WebSocketConfigurer {
                         "https://*.dorder-api.shop",
                         "https://*.netlify.app"
                 )
-                .addInterceptors(new HttpSessionHandshakeInterceptor());
+                .addInterceptors(staffCallHandshakeInterceptor, new HttpSessionHandshakeInterceptor());
 
         registry.addHandler(staffCallWebSocketHandler, "/ws/server/staffcall")
                 .setAllowedOriginPatterns(

--- a/spring/src/main/java/com/example/spring/service/serving/ServingTaskService.java
+++ b/spring/src/main/java/com/example/spring/service/serving/ServingTaskService.java
@@ -186,7 +186,7 @@ public class ServingTaskService {
             task.acceptServing();
 
             publishToDjango(boothId, "serving", task.getOrderItemId());
-            webSocketHandler.broadcastEvent("CATCH_CALL", ServingTaskResponse.from(task));
+            webSocketHandler.broadcastEvent(boothId, "CATCH_CALL", ServingTaskResponse.from(task));
 
         } finally {
             redisTemplate.delete(lockKey);
@@ -205,7 +205,7 @@ public class ServingTaskService {
         task.completeServing();
 
         publishToDjango(boothId, "served", task.getOrderItemId());
-        webSocketHandler.broadcastEvent("COMPLETE_CALL", ServingTaskResponse.from(task));
+        webSocketHandler.broadcastEvent(boothId, "COMPLETE_CALL", ServingTaskResponse.from(task));
     }
 
     @Transactional
@@ -220,7 +220,7 @@ public class ServingTaskService {
         task.cancelServing();
 
         publishToDjango(boothId, "cooked", task.getOrderItemId());
-        webSocketHandler.broadcastEvent("CANCEL_CALL", ServingTaskResponse.from(task));
+        webSocketHandler.broadcastEvent(boothId, "CANCEL_CALL", ServingTaskResponse.from(task));
     }
 
     @Transactional
@@ -250,7 +250,7 @@ public class ServingTaskService {
 
         servingTaskRepository.save(newTask);
 
-        webSocketHandler.broadcastEvent("NEW_CALL", ServingTaskResponse.from(newTask));
+        webSocketHandler.broadcastEvent(boothId, "NEW_CALL", ServingTaskResponse.from(newTask));
         log.info("[새 서빙 요청 생성 및 브로드캐스트] boothId={}, orderItemId={}", boothId, orderItemId);
     }
 
@@ -263,6 +263,7 @@ public class ServingTaskService {
         );
         if (deletedCount > 0) {
             webSocketHandler.broadcastEvent(
+                    boothId,
                     "REMOVE_CALL",
                     buildRemoveCallPayload(boothId, reason, deletedCount, orderItemId, null)
             );
@@ -279,6 +280,7 @@ public class ServingTaskService {
         );
         if (deletedCount > 0) {
             webSocketHandler.broadcastEvent(
+                    boothId,
                     "REMOVE_CALL",
                     buildRemoveCallPayload(boothId, reason, deletedCount, null, tableNumber)
             );

--- a/spring/src/main/java/com/example/spring/websocket/ServingWebSocketHandler.java
+++ b/spring/src/main/java/com/example/spring/websocket/ServingWebSocketHandler.java
@@ -15,49 +15,89 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static com.example.spring.config.StaffCallHandshakeInterceptor.ATTR_BOOTH_ID;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class ServingWebSocketHandler extends TextWebSocketHandler {
 
-    private final Set<WebSocketSession> sessions = ConcurrentHashMap.newKeySet();
+    private final Map<Long, Set<WebSocketSession>> boothSessions = new ConcurrentHashMap<>();
     private final ObjectMapper objectMapper;
 
     @Override
     public void afterConnectionEstablished(WebSocketSession session) {
-        sessions.add(session);
-        log.info("[웹소켓 접속] 새 태블릿 연결됨: {}", session.getId());
+        Object boothAttr = session.getAttributes().get(ATTR_BOOTH_ID);
+        if (!(boothAttr instanceof Long boothId)) {
+            log.warn("[serving ws] boothId 속성이 없어 연결 종료 session={}", session.getId());
+            try {
+                session.close(CloseStatus.NOT_ACCEPTABLE);
+            } catch (IOException e) {
+                log.warn("[serving ws] 연결 종료 실패 session={}", session.getId(), e);
+            }
+            return;
+        }
+
+        boothSessions.computeIfAbsent(boothId, key -> ConcurrentHashMap.newKeySet()).add(session);
+        log.info("[serving ws] 연결 boothId={}, session={}", boothId, session.getId());
     }
 
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
-        sessions.remove(session);
-        log.info("[웹소켓 해제] 태블릿 연결 끊김: {}", session.getId());
-    }
-
-    public void broadcastMessage(String message) {
-        TextMessage textMessage = new TextMessage(message);
-        for (WebSocketSession session : sessions) {
-            try {
-                if (session.isOpen()) {
-                    session.sendMessage(textMessage);
+        Object boothAttr = session.getAttributes().get(ATTR_BOOTH_ID);
+        if (boothAttr instanceof Long boothId) {
+            Set<WebSocketSession> sessions = boothSessions.get(boothId);
+            if (sessions != null) {
+                sessions.remove(session);
+                if (sessions.isEmpty()) {
+                    boothSessions.remove(boothId);
                 }
-            } catch (IOException e) {
-                log.error("[웹소켓 전송 실패] session: {}", session.getId(), e);
             }
+            log.info("[serving ws] 연결 해제 boothId={}, session={}, status={}", boothId, session.getId(), status);
+        } else {
+            log.info("[serving ws] 연결 해제(boothId 없음) session={}, status={}", session.getId(), status);
         }
     }
 
-    public void broadcastEvent(String eventType, Object data) {
+    public void broadcastEvent(Long boothId, String eventType, Object data) {
+        if (boothId == null) {
+            log.warn("[serving ws] boothId null로 이벤트 전송 스킵 eventType={}", eventType);
+            return;
+        }
+
+        Set<WebSocketSession> sessions = boothSessions.get(boothId);
+        int targetCount = sessions == null ? 0 : sessions.size();
+        log.info("[serving ws] 이벤트 브로드캐스트 boothId={}, eventType={}, targets={}", boothId, eventType, targetCount);
+
+        if (sessions == null || sessions.isEmpty()) {
+            return;
+        }
+
         try {
             Map<String, Object> payload = new HashMap<>();
             payload.put("type", eventType);
             payload.put("data", data);
 
-            String jsonMessage = objectMapper.writeValueAsString(payload);
-            broadcastMessage(jsonMessage);
+            TextMessage textMessage = new TextMessage(objectMapper.writeValueAsString(payload));
+
+            for (WebSocketSession session : sessions) {
+                if (!session.isOpen()) {
+                    sessions.remove(session);
+                    continue;
+                }
+                try {
+                    session.sendMessage(textMessage);
+                } catch (IOException e) {
+                    sessions.remove(session);
+                    log.warn("[serving ws] 전송 실패 boothId={}, session={}", boothId, session.getId(), e);
+                }
+            }
+
+            if (sessions.isEmpty()) {
+                boothSessions.remove(boothId);
+            }
         } catch (Exception e) {
-            log.error("[웹소켓 이벤트 직렬화 실패]", e);
+            log.error("[serving ws] 이벤트 직렬화 실패 boothId={}, eventType={}", boothId, eventType, e);
         }
     }
 }


### PR DESCRIPTION
<!-- ✨ [Feat] / 🐛 [Fix] / 📝 [Docs] / ♻️ [Refactor] / 🔧 [Chore] -->
## 🔍 What is the PR?

🐛 [Fix] Serving WebSocket 부스별 세션 분리

- `/ws/serving` WebSocket 연결 시 boothId 기준으로 세션을 분리하도록 수정
- 기존 전체 세션 broadcast 구조를 boothId별 broadcast 구조로 변경
- `NEW_CALL`, `CATCH_CALL`, `COMPLETE_CALL`, `CANCEL_CALL`, `REMOVE_CALL` 이벤트가 해당 부스 클라이언트에게만 전달되도록 수정

## 📍 PR Point

- 다른 부스의 서빙 요청이 서빙 화면에 잠깐 노출되는 문제를 해결했습니다.
- StaffCall WebSocket과 동일하게 boothId 기반 세션 관리 구조를 적용했습니다.
- boothId가 없는 경우 전체 broadcast로 fallback하지 않고 전송을 스킵하도록 처리했습니다.

## 📢 Notices

- WebSocket 메시지 payload 구조는 변경하지 않았습니다.
- 프론트엔드 수신 구조는 기존과 동일합니다.
- 변경 범위는 Serving WebSocket 관련 Spring 코드입니다.

## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?
- [x] 부스별 WebSocket 이벤트 분리 확인

## 💭 Related Issues

- #427 